### PR TITLE
Complete Conway predicate failure decoding

### DIFF
--- a/docs/error_parser.rs
+++ b/docs/error_parser.rs
@@ -1,0 +1,1537 @@
+//! Utilities for decoding the ledger predicate failures that are
+//! serialized as tagged CBOR sums.  The goal of this module is to keep the
+//! low-level CBOR handling in one place so the types defined in
+//! `rust_rule_errors.rs` can be connected to a real decoder without having to
+//! manually pattern-match every constructor.
+//!
+//! The module exposes two views over an error message:
+//!
+//! * [`TaggedTree`] keeps the generic structure for tooling that wants to walk
+//!   the CBOR representation without committing to any specific era.
+//! * [`decode_conway_ledger_failures_bytes`] converts the Conway-era ledger
+//!   predicate failures into enums keyed by their constructor tags so callers
+//!   can pattern match on concrete error cases.
+
+use ciborium::{de, value::Integer, value::Value};
+use std::{convert::TryFrom, fmt, io};
+
+/// Error returned while building a [`TaggedTree`].
+#[derive(Debug)]
+pub enum ParseError {
+    /// The message could not be decoded from CBOR.
+    Cbor(de::Error<std::io::Error>),
+    /// The structure was not a tagged sum as expected.
+    Malformed(&'static str),
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseError::Cbor(err) => write!(f, "CBOR decoding error: {err}"),
+            ParseError::Malformed(msg) => write!(f, "malformed predicate failure: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ParseError::Cbor(err) => Some(err),
+            ParseError::Malformed(_) => None,
+        }
+    }
+}
+
+impl From<de::Error<io::Error>> for ParseError {
+    fn from(err: de::Error<io::Error>) -> Self {
+        ParseError::Cbor(err)
+    }
+}
+
+/// Minimal CBOR term representation that keeps ordering information for arrays
+/// and key/value pairs for maps.  The intention is to resolve the term into the
+/// helper structs defined in `rust_rule_errors.rs` in a later pass once we wire
+/// up serde-based decoding.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Term {
+    Integer(Integer),
+    Bytes(Vec<u8>),
+    Text(String),
+    Bool(bool),
+    Float(f64),
+    Null,
+    Array(Vec<Term>),
+    Map(Vec<(Term, Term)>),
+    Tagged(u64, Box<Term>),
+}
+
+impl Term {
+    fn from_value(value: Value) -> Term {
+        match value {
+            Value::Integer(int) => Term::Integer(int),
+            Value::Bytes(bytes) => Term::Bytes(bytes),
+            Value::Text(text) => Term::Text(text),
+            Value::Bool(b) => Term::Bool(b),
+            Value::Null => Term::Null,
+            Value::Float(f) => Term::Float(f),
+            Value::Array(items) => Term::Array(items.into_iter().map(Term::from_value).collect()),
+            Value::Map(entries) => Term::Map(
+                entries
+                    .into_iter()
+                    .map(|(k, v)| (Term::from_value(k), Term::from_value(v)))
+                    .collect(),
+            ),
+            Value::Tag(tag, boxed) => Term::Tagged(tag, Box::new(Term::from_value(*boxed))),
+        }
+    }
+
+    fn as_unsigned(&self) -> Option<u64> {
+        match self {
+            Term::Integer(int) => u64::try_from(int.clone()).ok(),
+            _ => None,
+        }
+    }
+}
+
+/// Representation of a CBOR-encoded sum value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TaggedSum {
+    pub tag: u64,
+    pub fields: Vec<Term>,
+}
+
+impl TaggedSum {
+    fn from_term(term: Term) -> Option<TaggedSum> {
+        match term {
+            Term::Array(mut elements) if !elements.is_empty() => {
+                let tag_term = elements.remove(0);
+                let tag = tag_term.as_unsigned()?;
+                Some(TaggedSum {
+                    tag,
+                    fields: elements,
+                })
+            }
+            Term::Tagged(tag, boxed) => {
+                if let Term::Array(mut elements) = *boxed {
+                    Some(TaggedSum {
+                        tag,
+                        fields: elements,
+                    })
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Tree structure that mirrors the nesting of predicate failures.  Each node
+/// is either a tagged sum (which corresponds to one constructor of a predicate
+/// failure) or a leaf containing an arbitrary CBOR term.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TaggedTree {
+    Sum(TaggedSum, Vec<TaggedTree>),
+    Leaf(Term),
+}
+
+impl TaggedTree {
+    fn from_term(term: Term) -> TaggedTree {
+        if let Some(sum) = TaggedSum::from_term(term.clone()) {
+            let children = sum
+                .fields
+                .iter()
+                .cloned()
+                .map(TaggedTree::from_term)
+                .collect();
+            TaggedTree::Sum(sum, children)
+        } else {
+            TaggedTree::Leaf(term)
+        }
+    }
+}
+
+/// Decode a CBOR message and build a [`TaggedTree`] describing its structure.
+///
+/// # Errors
+///
+/// Returns [`ParseError::Malformed`] if the input cannot be interpreted as a
+/// tagged sum and [`ParseError::Cbor`] if the raw bytes are not valid CBOR.
+pub fn decode_predicate_failure<R: io::Read>(reader: R) -> Result<TaggedTree, ParseError> {
+    let value: Value = de::from_reader(reader)?;
+    let root = Term::from_value(value);
+    if TaggedSum::from_term(root.clone()).is_none() {
+        return Err(ParseError::Malformed("expected a tagged sum"));
+    }
+    Ok(TaggedTree::from_term(root))
+}
+
+/// Convenience helper for decoding from an in-memory slice.
+pub fn decode_predicate_failure_bytes(bytes: &[u8]) -> Result<TaggedTree, ParseError> {
+    decode_predicate_failure(bytes)
+}
+
+/// Conway-specific view of the predicate failure hierarchy.  The helper enums
+/// below capture the numeric tags so callers can match on constructors without
+/// reimplementing the CBOR parsing logic.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConwayLedgerPredicateFailure {
+    UtxowFailure(Box<ConwayUtxowPredicateFailure>),
+    CertsFailure(Box<ConwayCertsPredicateFailure>),
+    GovFailure(Box<ConwayGovPredicateFailure>),
+    WdrlNotDelegatedToDRep { withdrawals: Term },
+    TreasuryValueMismatch { mismatch: Term },
+    TxRefScriptsSizeTooBig { size_mismatch: Term },
+    MempoolFailure { reason: Term },
+    WithdrawalsMissingAccounts { withdrawals: Term },
+    IncompleteWithdrawals { withdrawals: Term },
+    Other(TaggedSum),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConwayUtxowPredicateFailure {
+    UtxoFailure(Box<ConwayUtxoPredicateFailure>),
+    InvalidWitnessesUTXOW {
+        witnesses: Term,
+    },
+    MissingVKeyWitnessesUTXOW {
+        missing: Term,
+    },
+    MissingScriptWitnessesUTXOW {
+        missing: Term,
+    },
+    ScriptWitnessNotValidatingUTXOW {
+        failing: Term,
+    },
+    MissingTxBodyMetadataHash {
+        expected: Term,
+    },
+    MissingTxMetadata {
+        expected: Term,
+    },
+    ConflictingMetadataHash {
+        mismatch: Term,
+    },
+    InvalidMetadata,
+    ExtraneousScriptWitnessesUTXOW {
+        extraneous: Term,
+    },
+    MissingRedeemers {
+        missing: Term,
+    },
+    MissingRequiredDatums {
+        missing_hashes: Term,
+        provided_hashes: Term,
+    },
+    NotAllowedSupplementalDatums {
+        disallowed_hashes: Term,
+        allowed: Term,
+    },
+    PPViewHashesDontMatch {
+        mismatch: Term,
+    },
+    UnspendableUTxONoDatumHash {
+        inputs: Term,
+    },
+    ExtraRedeemers {
+        extra: Term,
+    },
+    MalformedScriptWitnesses {
+        scripts: Term,
+    },
+    MalformedReferenceScripts {
+        scripts: Term,
+    },
+    ScriptIntegrityHashMismatch {
+        mismatch: Term,
+        provided: Term,
+    },
+    Other(TaggedSum),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConwayUtxoPredicateFailure {
+    UtxosFailure(Box<ConwayUtxosPredicateFailure>),
+    BadInputsUTxO {
+        invalid_inputs: Term,
+    },
+    OutsideValidityIntervalUTxO {
+        validity_interval: Term,
+        current_slot: Term,
+    },
+    MaxTxSizeUTxO {
+        size_mismatch: Term,
+    },
+    InputSetEmptyUTxO,
+    FeeTooSmallUTxO {
+        fee_mismatch: Term,
+    },
+    ValueNotConservedUTxO {
+        balance_mismatch: Term,
+    },
+    WrongNetwork {
+        expected: Term,
+        offending: Term,
+    },
+    WrongNetworkWithdrawal {
+        expected: Term,
+        offending: Term,
+    },
+    OutputTooSmallUTxO {
+        tiny_outputs: Term,
+    },
+    OutputBootAddrAttrsTooBig {
+        oversized_bootstrap_outputs: Term,
+    },
+    OutputTooBigUTxO {
+        outputs: Term,
+    },
+    InsufficientCollateral {
+        provided: Term,
+        required: Term,
+    },
+    ScriptsNotPaidUTxO {
+        unpaid: Term,
+    },
+    ExUnitsTooBigUTxO {
+        limit_mismatch: Term,
+    },
+    CollateralContainsNonADA {
+        offending_value: Term,
+    },
+    WrongNetworkInTxBody {
+        mismatch: Term,
+    },
+    OutsideForecast {
+        slot: Term,
+    },
+    TooManyCollateralInputs {
+        bound: Term,
+    },
+    NoCollateralInputs,
+    IncorrectTotalCollateralField {
+        provided: Term,
+        declared: Term,
+    },
+    BabbageOutputTooSmallUTxO {
+        outputs: Term,
+    },
+    BabbageNonDisjointRefInputs {
+        overlapping: Term,
+    },
+    Other(TaggedSum),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConwayUtxosPredicateFailure {
+    ValidationTagMismatch { tag: Term, description: Term },
+    CollectErrors { errors: Term },
+    Other(TaggedSum),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConwayCertsPredicateFailure {
+    WithdrawalsNotInRewardsCERTS { withdrawals: Term },
+    CertFailure(Box<ConwayCertPredicateFailure>),
+    Other(TaggedSum),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConwayCertPredicateFailure {
+    DelegFailure(Box<ConwayDelegPredicateFailure>),
+    PoolFailure { failure: Term },
+    GovCertFailure(Box<ConwayGovCertPredicateFailure>),
+    Other(TaggedSum),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConwayDelegPredicateFailure {
+    IncorrectDeposit { deposit: Term },
+    StakeKeyRegistered { stake_credential: Term },
+    StakeKeyNotRegistered { stake_credential: Term },
+    StakeKeyHasNonZeroRewardAccountBalance { balance: Term },
+    DelegateeDRepNotRegistered { delegatee: Term },
+    DelegateeStakePoolNotRegistered { delegatee: Vec<u8> },
+    DepositIncorrect { mismatch: Term },
+    RefundIncorrect { mismatch: Term },
+    Other(TaggedSum),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConwayGovCertPredicateFailure {
+    ConwayDRepAlreadyRegistered { credential: Term },
+    ConwayDRepNotRegistered { credential: Term },
+    ConwayDRepIncorrectDeposit { mismatch: Term },
+    ConwayCommitteeHasPreviouslyResigned { cold_credential: Term },
+    ConwayDRepIncorrectRefund { mismatch: Term },
+    ConwayCommitteeIsUnknown { cold_credential: Term },
+    Other(TaggedSum),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConwayGovPredicateFailure {
+    GovActionsDoNotExist {
+        missing: Term,
+    },
+    MalformedProposal {
+        proposal: Term,
+    },
+    ProposalProcedureNetworkIdMismatch {
+        reward_account: Term,
+        expected_network: Term,
+    },
+    TreasuryWithdrawalsNetworkIdMismatch {
+        offending_accounts: Term,
+        expected_network: Term,
+    },
+    ProposalDepositIncorrect {
+        mismatch: Term,
+    },
+    DisallowedVoters {
+        voters: Term,
+    },
+    ConflictingCommitteeUpdate {
+        members: Term,
+    },
+    ExpirationEpochTooSmall {
+        expired: Term,
+    },
+    InvalidPrevGovActionId {
+        proposal: Term,
+    },
+    VotingOnExpiredGovAction {
+        votes: Term,
+    },
+    ProposalCantFollow {
+        previous: Term,
+        version_mismatch: Term,
+    },
+    InvalidPolicyHash {
+        provided: Term,
+        expected: Term,
+    },
+    DisallowedProposalDuringBootstrap {
+        proposal: Term,
+    },
+    DisallowedVotesDuringBootstrap {
+        votes: Term,
+    },
+    VotersDoNotExist {
+        voters: Term,
+    },
+    ZeroTreasuryWithdrawals {
+        action: Term,
+    },
+    ProposalReturnAccountDoesNotExist {
+        reward_account: Term,
+    },
+    TreasuryWithdrawalReturnAccountsDoNotExist {
+        reward_accounts: Term,
+    },
+    UnelectedCommitteeVoters {
+        voters: Term,
+    },
+    Other(TaggedSum),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConwayLedgerPredicateFailureTag {
+    ConwayUtxowFailure = 1,
+    ConwayCertsFailure = 2,
+    ConwayGovFailure = 3,
+    ConwayWdrlNotDelegatedToDRep = 4,
+    ConwayTreasuryValueMismatch = 5,
+    ConwayTxRefScriptsSizeTooBig = 6,
+    ConwayMempoolFailure = 7,
+    ConwayWithdrawalsMissingAccounts = 8,
+    ConwayIncompleteWithdrawals = 9,
+}
+
+impl TryFrom<u64> for ConwayLedgerPredicateFailureTag {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::ConwayUtxowFailure),
+            2 => Ok(Self::ConwayCertsFailure),
+            3 => Ok(Self::ConwayGovFailure),
+            4 => Ok(Self::ConwayWdrlNotDelegatedToDRep),
+            5 => Ok(Self::ConwayTreasuryValueMismatch),
+            6 => Ok(Self::ConwayTxRefScriptsSizeTooBig),
+            7 => Ok(Self::ConwayMempoolFailure),
+            8 => Ok(Self::ConwayWithdrawalsMissingAccounts),
+            9 => Ok(Self::ConwayIncompleteWithdrawals),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConwayUtxowPredicateFailureTag {
+    UtxoFailure = 0,
+    InvalidWitnessesUTXOW = 1,
+    MissingVKeyWitnessesUTXOW = 2,
+    MissingScriptWitnessesUTXOW = 3,
+    ScriptWitnessNotValidatingUTXOW = 4,
+    MissingTxBodyMetadataHash = 5,
+    MissingTxMetadata = 6,
+    ConflictingMetadataHash = 7,
+    InvalidMetadata = 8,
+    ExtraneousScriptWitnessesUTXOW = 9,
+    MissingRedeemers = 10,
+    MissingRequiredDatums = 11,
+    NotAllowedSupplementalDatums = 12,
+    PPViewHashesDontMatch = 13,
+    UnspendableUTxONoDatumHash = 14,
+    ExtraRedeemers = 15,
+    MalformedScriptWitnesses = 16,
+    MalformedReferenceScripts = 17,
+    ScriptIntegrityHashMismatch = 18,
+}
+
+impl TryFrom<u64> for ConwayUtxowPredicateFailureTag {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::UtxoFailure),
+            1 => Ok(Self::InvalidWitnessesUTXOW),
+            2 => Ok(Self::MissingVKeyWitnessesUTXOW),
+            3 => Ok(Self::MissingScriptWitnessesUTXOW),
+            4 => Ok(Self::ScriptWitnessNotValidatingUTXOW),
+            5 => Ok(Self::MissingTxBodyMetadataHash),
+            6 => Ok(Self::MissingTxMetadata),
+            7 => Ok(Self::ConflictingMetadataHash),
+            8 => Ok(Self::InvalidMetadata),
+            9 => Ok(Self::ExtraneousScriptWitnessesUTXOW),
+            10 => Ok(Self::MissingRedeemers),
+            11 => Ok(Self::MissingRequiredDatums),
+            12 => Ok(Self::NotAllowedSupplementalDatums),
+            13 => Ok(Self::PPViewHashesDontMatch),
+            14 => Ok(Self::UnspendableUTxONoDatumHash),
+            15 => Ok(Self::ExtraRedeemers),
+            16 => Ok(Self::MalformedScriptWitnesses),
+            17 => Ok(Self::MalformedReferenceScripts),
+            18 => Ok(Self::ScriptIntegrityHashMismatch),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConwayUtxoPredicateFailureTag {
+    UtxosFailure = 0,
+    BadInputsUTxO = 1,
+    OutsideValidityIntervalUTxO = 2,
+    MaxTxSizeUTxO = 3,
+    InputSetEmptyUTxO = 4,
+    FeeTooSmallUTxO = 5,
+    ValueNotConservedUTxO = 6,
+    WrongNetwork = 7,
+    WrongNetworkWithdrawal = 8,
+    OutputTooSmallUTxO = 9,
+    OutputBootAddrAttrsTooBig = 10,
+    OutputTooBigUTxO = 11,
+    InsufficientCollateral = 12,
+    ScriptsNotPaidUTxO = 13,
+    ExUnitsTooBigUTxO = 14,
+    CollateralContainsNonADA = 15,
+    WrongNetworkInTxBody = 16,
+    OutsideForecast = 17,
+    TooManyCollateralInputs = 18,
+    NoCollateralInputs = 19,
+    IncorrectTotalCollateralField = 20,
+    BabbageOutputTooSmallUTxO = 21,
+    BabbageNonDisjointRefInputs = 22,
+}
+
+impl TryFrom<u64> for ConwayUtxoPredicateFailureTag {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::UtxosFailure),
+            1 => Ok(Self::BadInputsUTxO),
+            2 => Ok(Self::OutsideValidityIntervalUTxO),
+            3 => Ok(Self::MaxTxSizeUTxO),
+            4 => Ok(Self::InputSetEmptyUTxO),
+            5 => Ok(Self::FeeTooSmallUTxO),
+            6 => Ok(Self::ValueNotConservedUTxO),
+            7 => Ok(Self::WrongNetwork),
+            8 => Ok(Self::WrongNetworkWithdrawal),
+            9 => Ok(Self::OutputTooSmallUTxO),
+            10 => Ok(Self::OutputBootAddrAttrsTooBig),
+            11 => Ok(Self::OutputTooBigUTxO),
+            12 => Ok(Self::InsufficientCollateral),
+            13 => Ok(Self::ScriptsNotPaidUTxO),
+            14 => Ok(Self::ExUnitsTooBigUTxO),
+            15 => Ok(Self::CollateralContainsNonADA),
+            16 => Ok(Self::WrongNetworkInTxBody),
+            17 => Ok(Self::OutsideForecast),
+            18 => Ok(Self::TooManyCollateralInputs),
+            19 => Ok(Self::NoCollateralInputs),
+            20 => Ok(Self::IncorrectTotalCollateralField),
+            21 => Ok(Self::BabbageOutputTooSmallUTxO),
+            22 => Ok(Self::BabbageNonDisjointRefInputs),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConwayUtxosPredicateFailureTag {
+    ValidationTagMismatch = 0,
+    CollectErrors = 1,
+}
+
+impl TryFrom<u64> for ConwayUtxosPredicateFailureTag {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::ValidationTagMismatch),
+            1 => Ok(Self::CollectErrors),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConwayCertsPredicateFailureTag {
+    WithdrawalsNotInRewardsCERTS = 0,
+    CertFailure = 1,
+}
+
+impl TryFrom<u64> for ConwayCertsPredicateFailureTag {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::WithdrawalsNotInRewardsCERTS),
+            1 => Ok(Self::CertFailure),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConwayCertPredicateFailureTag {
+    DelegFailure = 1,
+    PoolFailure = 2,
+    GovCertFailure = 3,
+}
+
+impl TryFrom<u64> for ConwayCertPredicateFailureTag {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::DelegFailure),
+            2 => Ok(Self::PoolFailure),
+            3 => Ok(Self::GovCertFailure),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConwayDelegPredicateFailureTag {
+    IncorrectDepositDELEG = 1,
+    StakeKeyRegisteredDELEG = 2,
+    StakeKeyNotRegisteredDELEG = 3,
+    StakeKeyHasNonZeroRewardAccountBalanceDELEG = 4,
+    DelegateeDRepNotRegisteredDELEG = 5,
+    DelegateeStakePoolNotRegisteredDELEG = 6,
+    DepositIncorrectDELEG = 7,
+    RefundIncorrectDELEG = 8,
+}
+
+impl TryFrom<u64> for ConwayDelegPredicateFailureTag {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::IncorrectDepositDELEG),
+            2 => Ok(Self::StakeKeyRegisteredDELEG),
+            3 => Ok(Self::StakeKeyNotRegisteredDELEG),
+            4 => Ok(Self::StakeKeyHasNonZeroRewardAccountBalanceDELEG),
+            5 => Ok(Self::DelegateeDRepNotRegisteredDELEG),
+            6 => Ok(Self::DelegateeStakePoolNotRegisteredDELEG),
+            7 => Ok(Self::DepositIncorrectDELEG),
+            8 => Ok(Self::RefundIncorrectDELEG),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConwayGovCertPredicateFailureTag {
+    ConwayDRepAlreadyRegistered = 0,
+    ConwayDRepNotRegistered = 1,
+    ConwayDRepIncorrectDeposit = 2,
+    ConwayCommitteeHasPreviouslyResigned = 3,
+    ConwayDRepIncorrectRefund = 4,
+    ConwayCommitteeIsUnknown = 5,
+}
+
+impl TryFrom<u64> for ConwayGovCertPredicateFailureTag {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::ConwayDRepAlreadyRegistered),
+            1 => Ok(Self::ConwayDRepNotRegistered),
+            2 => Ok(Self::ConwayDRepIncorrectDeposit),
+            3 => Ok(Self::ConwayCommitteeHasPreviouslyResigned),
+            4 => Ok(Self::ConwayDRepIncorrectRefund),
+            5 => Ok(Self::ConwayCommitteeIsUnknown),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConwayGovPredicateFailureTag {
+    GovActionsDoNotExist = 0,
+    MalformedProposal = 1,
+    ProposalProcedureNetworkIdMismatch = 2,
+    TreasuryWithdrawalsNetworkIdMismatch = 3,
+    ProposalDepositIncorrect = 4,
+    DisallowedVoters = 5,
+    ConflictingCommitteeUpdate = 6,
+    ExpirationEpochTooSmall = 7,
+    InvalidPrevGovActionId = 8,
+    VotingOnExpiredGovAction = 9,
+    ProposalCantFollow = 10,
+    InvalidPolicyHash = 11,
+    DisallowedProposalDuringBootstrap = 12,
+    DisallowedVotesDuringBootstrap = 13,
+    VotersDoNotExist = 14,
+    ZeroTreasuryWithdrawals = 15,
+    ProposalReturnAccountDoesNotExist = 16,
+    TreasuryWithdrawalReturnAccountsDoNotExist = 17,
+    UnelectedCommitteeVoters = 18,
+}
+
+impl TryFrom<u64> for ConwayGovPredicateFailureTag {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::GovActionsDoNotExist),
+            1 => Ok(Self::MalformedProposal),
+            2 => Ok(Self::ProposalProcedureNetworkIdMismatch),
+            3 => Ok(Self::TreasuryWithdrawalsNetworkIdMismatch),
+            4 => Ok(Self::ProposalDepositIncorrect),
+            5 => Ok(Self::DisallowedVoters),
+            6 => Ok(Self::ConflictingCommitteeUpdate),
+            7 => Ok(Self::ExpirationEpochTooSmall),
+            8 => Ok(Self::InvalidPrevGovActionId),
+            9 => Ok(Self::VotingOnExpiredGovAction),
+            10 => Ok(Self::ProposalCantFollow),
+            11 => Ok(Self::InvalidPolicyHash),
+            12 => Ok(Self::DisallowedProposalDuringBootstrap),
+            13 => Ok(Self::DisallowedVotesDuringBootstrap),
+            14 => Ok(Self::VotersDoNotExist),
+            15 => Ok(Self::ZeroTreasuryWithdrawals),
+            16 => Ok(Self::ProposalReturnAccountDoesNotExist),
+            17 => Ok(Self::TreasuryWithdrawalReturnAccountsDoNotExist),
+            18 => Ok(Self::UnelectedCommitteeVoters),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Decode the message into the Conway ledger predicate failures.  Any
+/// constructors we do not recognise are returned as raw [`TaggedSum`] values so
+/// future work can extend the match arms without re-parsing the CBOR.
+pub fn decode_conway_ledger_failures<R: io::Read>(
+    reader: R,
+) -> Result<Vec<ConwayLedgerPredicateFailure>, ParseError> {
+    let value: Value = de::from_reader(reader)?;
+    let term = Term::from_value(value);
+    let body = match term {
+        Term::Array(mut elements) if elements.len() == 2 => {
+            elements.remove(0);
+            elements.remove(0)
+        }
+        _ => {
+            return Err(ParseError::Malformed(
+                "expected [tag, body] predicate failure message",
+            ))
+        }
+    };
+
+    let failures = match body {
+        Term::Array(elements) => elements,
+        _ => {
+            return Err(ParseError::Malformed(
+                "predicate failure body must be an array",
+            ))
+        }
+    };
+
+    failures
+        .into_iter()
+        .map(parse_conway_ledger_failure)
+        .collect()
+}
+
+/// Convenience helper mirroring [`decode_conway_ledger_failures`] for an
+/// in-memory message buffer.
+pub fn decode_conway_ledger_failures_bytes(
+    bytes: &[u8],
+) -> Result<Vec<ConwayLedgerPredicateFailure>, ParseError> {
+    decode_conway_ledger_failures(bytes)
+}
+
+fn parse_conway_ledger_failure(term: Term) -> Result<ConwayLedgerPredicateFailure, ParseError> {
+    let sum = TaggedSum::from_term(term).ok_or(ParseError::Malformed(
+        "ledger predicate failure node must be a tagged sum",
+    ))?;
+
+    match ConwayLedgerPredicateFailureTag::try_from(sum.tag) {
+        Ok(ConwayLedgerPredicateFailureTag::ConwayUtxowFailure) => {
+            let field =
+                expect_single_field(sum.fields, "ConwayUtxowFailure expects a single payload")?;
+            let utxow = parse_conway_utxow_failure(field)?;
+            Ok(ConwayLedgerPredicateFailure::UtxowFailure(Box::new(utxow)))
+        }
+        Ok(ConwayLedgerPredicateFailureTag::ConwayCertsFailure) => {
+            let child =
+                expect_single_field(sum.fields, "ConwayCertsFailure expects a single payload")?;
+            let certs = parse_conway_certs_failure(child)?;
+            Ok(ConwayLedgerPredicateFailure::CertsFailure(Box::new(certs)))
+        }
+        Ok(ConwayLedgerPredicateFailureTag::ConwayGovFailure) => {
+            let child =
+                expect_single_field(sum.fields, "ConwayGovFailure expects a single payload")?;
+            let gov = parse_conway_gov_failure(child)?;
+            Ok(ConwayLedgerPredicateFailure::GovFailure(Box::new(gov)))
+        }
+        Ok(ConwayLedgerPredicateFailureTag::ConwayWdrlNotDelegatedToDRep) => {
+            let withdrawals = expect_single_field(
+                sum.fields,
+                "ConwayWdrlNotDelegatedToDRep expects withdrawals",
+            )?;
+            Ok(ConwayLedgerPredicateFailure::WdrlNotDelegatedToDRep { withdrawals })
+        }
+        Ok(ConwayLedgerPredicateFailureTag::ConwayTreasuryValueMismatch) => {
+            let mismatch = expect_single_field(
+                sum.fields,
+                "ConwayTreasuryValueMismatch expects mismatch payload",
+            )?;
+            Ok(ConwayLedgerPredicateFailure::TreasuryValueMismatch { mismatch })
+        }
+        Ok(ConwayLedgerPredicateFailureTag::ConwayTxRefScriptsSizeTooBig) => {
+            let size_mismatch = expect_single_field(
+                sum.fields,
+                "ConwayTxRefScriptsSizeTooBig expects mismatch payload",
+            )?;
+            Ok(ConwayLedgerPredicateFailure::TxRefScriptsSizeTooBig { size_mismatch })
+        }
+        Ok(ConwayLedgerPredicateFailureTag::ConwayMempoolFailure) => {
+            let reason =
+                expect_single_field(sum.fields, "ConwayMempoolFailure expects reason payload")?;
+            Ok(ConwayLedgerPredicateFailure::MempoolFailure { reason })
+        }
+        Ok(ConwayLedgerPredicateFailureTag::ConwayWithdrawalsMissingAccounts) => {
+            let withdrawals = expect_single_field(
+                sum.fields,
+                "ConwayWithdrawalsMissingAccounts expects withdrawals",
+            )?;
+            Ok(ConwayLedgerPredicateFailure::WithdrawalsMissingAccounts { withdrawals })
+        }
+        Ok(ConwayLedgerPredicateFailureTag::ConwayIncompleteWithdrawals) => {
+            let withdrawals = expect_single_field(
+                sum.fields,
+                "ConwayIncompleteWithdrawals expects withdrawals",
+            )?;
+            Ok(ConwayLedgerPredicateFailure::IncompleteWithdrawals { withdrawals })
+        }
+        _ => Ok(ConwayLedgerPredicateFailure::Other(sum)),
+    }
+}
+
+fn parse_conway_utxow_failure(term: Term) -> Result<ConwayUtxowPredicateFailure, ParseError> {
+    let sum = TaggedSum::from_term(term).ok_or(ParseError::Malformed(
+        "utxow predicate failure must be a tagged sum",
+    ))?;
+
+    match ConwayUtxowPredicateFailureTag::try_from(sum.tag) {
+        Ok(ConwayUtxowPredicateFailureTag::UtxoFailure) => {
+            let child = expect_single_field(sum.fields, "UtxoFailure expects a single payload")?;
+            let utxo = parse_conway_utxo_failure(child)?;
+            Ok(ConwayUtxowPredicateFailure::UtxoFailure(Box::new(utxo)))
+        }
+        Ok(ConwayUtxowPredicateFailureTag::InvalidWitnessesUTXOW) => {
+            let witnesses =
+                expect_single_field(sum.fields, "InvalidWitnessesUTXOW expects witness payload")?;
+            Ok(ConwayUtxowPredicateFailure::InvalidWitnessesUTXOW { witnesses })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::MissingVKeyWitnessesUTXOW) => {
+            let missing = expect_single_field(
+                sum.fields,
+                "MissingVKeyWitnessesUTXOW expects missing payload",
+            )?;
+            Ok(ConwayUtxowPredicateFailure::MissingVKeyWitnessesUTXOW { missing })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::MissingScriptWitnessesUTXOW) => {
+            let missing = expect_single_field(
+                sum.fields,
+                "MissingScriptWitnessesUTXOW expects missing payload",
+            )?;
+            Ok(ConwayUtxowPredicateFailure::MissingScriptWitnessesUTXOW { missing })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::ScriptWitnessNotValidatingUTXOW) => {
+            let failing = expect_single_field(
+                sum.fields,
+                "ScriptWitnessNotValidatingUTXOW expects failing payload",
+            )?;
+            Ok(ConwayUtxowPredicateFailure::ScriptWitnessNotValidatingUTXOW { failing })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::MissingTxBodyMetadataHash) => {
+            let expected = expect_single_field(
+                sum.fields,
+                "MissingTxBodyMetadataHash expects expected hash",
+            )?;
+            Ok(ConwayUtxowPredicateFailure::MissingTxBodyMetadataHash { expected })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::MissingTxMetadata) => {
+            let expected =
+                expect_single_field(sum.fields, "MissingTxMetadata expects expected hash")?;
+            Ok(ConwayUtxowPredicateFailure::MissingTxMetadata { expected })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::ConflictingMetadataHash) => {
+            let mismatch = expect_single_field(
+                sum.fields,
+                "ConflictingMetadataHash expects mismatch payload",
+            )?;
+            Ok(ConwayUtxowPredicateFailure::ConflictingMetadataHash { mismatch })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::InvalidMetadata) => {
+            expect_no_fields(sum.fields, "InvalidMetadata carries no payload")?;
+            Ok(ConwayUtxowPredicateFailure::InvalidMetadata)
+        }
+        Ok(ConwayUtxowPredicateFailureTag::ExtraneousScriptWitnessesUTXOW) => {
+            let extraneous =
+                expect_single_field(sum.fields, "ExtraneousScriptWitnessesUTXOW expects payload")?;
+            Ok(ConwayUtxowPredicateFailure::ExtraneousScriptWitnessesUTXOW { extraneous })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::MissingRedeemers) => {
+            let missing = expect_single_field(sum.fields, "MissingRedeemers expects payload")?;
+            Ok(ConwayUtxowPredicateFailure::MissingRedeemers { missing })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::MissingRequiredDatums) => {
+            let (missing_hashes, provided_hashes) =
+                expect_two_fields(sum.fields, "MissingRequiredDatums expects two payloads")?;
+            Ok(ConwayUtxowPredicateFailure::MissingRequiredDatums {
+                missing_hashes,
+                provided_hashes,
+            })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::NotAllowedSupplementalDatums) => {
+            let (disallowed_hashes, allowed) = expect_two_fields(
+                sum.fields,
+                "NotAllowedSupplementalDatums expects two payloads",
+            )?;
+            Ok(ConwayUtxowPredicateFailure::NotAllowedSupplementalDatums {
+                disallowed_hashes,
+                allowed,
+            })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::PPViewHashesDontMatch) => {
+            let mismatch =
+                expect_single_field(sum.fields, "PPViewHashesDontMatch expects mismatch payload")?;
+            Ok(ConwayUtxowPredicateFailure::PPViewHashesDontMatch { mismatch })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::UnspendableUTxONoDatumHash) => {
+            let inputs =
+                expect_single_field(sum.fields, "UnspendableUTxONoDatumHash expects input set")?;
+            Ok(ConwayUtxowPredicateFailure::UnspendableUTxONoDatumHash { inputs })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::ExtraRedeemers) => {
+            let extra = expect_single_field(sum.fields, "ExtraRedeemers expects payload")?;
+            Ok(ConwayUtxowPredicateFailure::ExtraRedeemers { extra })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::MalformedScriptWitnesses) => {
+            let scripts =
+                expect_single_field(sum.fields, "MalformedScriptWitnesses expects payload")?;
+            Ok(ConwayUtxowPredicateFailure::MalformedScriptWitnesses { scripts })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::MalformedReferenceScripts) => {
+            let scripts =
+                expect_single_field(sum.fields, "MalformedReferenceScripts expects payload")?;
+            Ok(ConwayUtxowPredicateFailure::MalformedReferenceScripts { scripts })
+        }
+        Ok(ConwayUtxowPredicateFailureTag::ScriptIntegrityHashMismatch) => {
+            let (mismatch, provided) = expect_two_fields(
+                sum.fields,
+                "ScriptIntegrityHashMismatch expects two payloads",
+            )?;
+            Ok(ConwayUtxowPredicateFailure::ScriptIntegrityHashMismatch { mismatch, provided })
+        }
+        _ => Ok(ConwayUtxowPredicateFailure::Other(sum)),
+    }
+}
+
+fn parse_conway_utxo_failure(term: Term) -> Result<ConwayUtxoPredicateFailure, ParseError> {
+    let sum = TaggedSum::from_term(term).ok_or(ParseError::Malformed(
+        "utxo predicate failure must be a tagged sum",
+    ))?;
+
+    match ConwayUtxoPredicateFailureTag::try_from(sum.tag) {
+        Ok(ConwayUtxoPredicateFailureTag::UtxosFailure) => {
+            let child = expect_single_field(sum.fields, "UtxosFailure expects a single payload")?;
+            let utxos = parse_conway_utxos_failure(child)?;
+            Ok(ConwayUtxoPredicateFailure::UtxosFailure(Box::new(utxos)))
+        }
+        Ok(ConwayUtxoPredicateFailureTag::BadInputsUTxO) => {
+            let invalid_inputs =
+                expect_single_field(sum.fields, "BadInputsUTxO expects invalid inputs payload")?;
+            Ok(ConwayUtxoPredicateFailure::BadInputsUTxO { invalid_inputs })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::OutsideValidityIntervalUTxO) => {
+            let (validity_interval, current_slot) = expect_two_fields(
+                sum.fields,
+                "OutsideValidityIntervalUTxO expects interval and slot",
+            )?;
+            Ok(ConwayUtxoPredicateFailure::OutsideValidityIntervalUTxO {
+                validity_interval,
+                current_slot,
+            })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::MaxTxSizeUTxO) => {
+            let size_mismatch =
+                expect_single_field(sum.fields, "MaxTxSizeUTxO expects mismatch payload")?;
+            Ok(ConwayUtxoPredicateFailure::MaxTxSizeUTxO { size_mismatch })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::InputSetEmptyUTxO) => {
+            expect_no_fields(sum.fields, "InputSetEmptyUTxO carries no payload")?;
+            Ok(ConwayUtxoPredicateFailure::InputSetEmptyUTxO)
+        }
+        Ok(ConwayUtxoPredicateFailureTag::FeeTooSmallUTxO) => {
+            let fee_mismatch =
+                expect_single_field(sum.fields, "FeeTooSmallUTxO expects mismatch payload")?;
+            Ok(ConwayUtxoPredicateFailure::FeeTooSmallUTxO { fee_mismatch })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::ValueNotConservedUTxO) => {
+            let balance_mismatch =
+                expect_single_field(sum.fields, "ValueNotConservedUTxO expects mismatch payload")?;
+            Ok(ConwayUtxoPredicateFailure::ValueNotConservedUTxO { balance_mismatch })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::WrongNetwork) => {
+            let (expected, offending) = expect_two_fields(
+                sum.fields,
+                "WrongNetwork expects expected/offending payloads",
+            )?;
+            Ok(ConwayUtxoPredicateFailure::WrongNetwork {
+                expected,
+                offending,
+            })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::WrongNetworkWithdrawal) => {
+            let (expected, offending) = expect_two_fields(
+                sum.fields,
+                "WrongNetworkWithdrawal expects expected/offending payloads",
+            )?;
+            Ok(ConwayUtxoPredicateFailure::WrongNetworkWithdrawal {
+                expected,
+                offending,
+            })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::OutputTooSmallUTxO) => {
+            let tiny_outputs =
+                expect_single_field(sum.fields, "OutputTooSmallUTxO expects outputs payload")?;
+            Ok(ConwayUtxoPredicateFailure::OutputTooSmallUTxO { tiny_outputs })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::OutputBootAddrAttrsTooBig) => {
+            let oversized_bootstrap_outputs = expect_single_field(
+                sum.fields,
+                "OutputBootAddrAttrsTooBig expects outputs payload",
+            )?;
+            Ok(ConwayUtxoPredicateFailure::OutputBootAddrAttrsTooBig {
+                oversized_bootstrap_outputs,
+            })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::OutputTooBigUTxO) => {
+            let outputs = expect_single_field(sum.fields, "OutputTooBigUTxO expects payload")?;
+            Ok(ConwayUtxoPredicateFailure::OutputTooBigUTxO { outputs })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::InsufficientCollateral) => {
+            let (provided, required) = expect_two_fields(
+                sum.fields,
+                "InsufficientCollateral expects provided/required",
+            )?;
+            Ok(ConwayUtxoPredicateFailure::InsufficientCollateral { provided, required })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::ScriptsNotPaidUTxO) => {
+            let unpaid = expect_single_field(sum.fields, "ScriptsNotPaidUTxO expects payload")?;
+            Ok(ConwayUtxoPredicateFailure::ScriptsNotPaidUTxO { unpaid })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::ExUnitsTooBigUTxO) => {
+            let limit_mismatch =
+                expect_single_field(sum.fields, "ExUnitsTooBigUTxO expects mismatch payload")?;
+            Ok(ConwayUtxoPredicateFailure::ExUnitsTooBigUTxO { limit_mismatch })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::CollateralContainsNonADA) => {
+            let offending_value =
+                expect_single_field(sum.fields, "CollateralContainsNonADA expects payload")?;
+            Ok(ConwayUtxoPredicateFailure::CollateralContainsNonADA { offending_value })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::WrongNetworkInTxBody) => {
+            let mismatch =
+                expect_single_field(sum.fields, "WrongNetworkInTxBody expects mismatch payload")?;
+            Ok(ConwayUtxoPredicateFailure::WrongNetworkInTxBody { mismatch })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::OutsideForecast) => {
+            let slot = expect_single_field(sum.fields, "OutsideForecast expects slot payload")?;
+            Ok(ConwayUtxoPredicateFailure::OutsideForecast { slot })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::TooManyCollateralInputs) => {
+            let bound =
+                expect_single_field(sum.fields, "TooManyCollateralInputs expects bound payload")?;
+            Ok(ConwayUtxoPredicateFailure::TooManyCollateralInputs { bound })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::NoCollateralInputs) => {
+            expect_no_fields(sum.fields, "NoCollateralInputs carries no payload")?;
+            Ok(ConwayUtxoPredicateFailure::NoCollateralInputs)
+        }
+        Ok(ConwayUtxoPredicateFailureTag::IncorrectTotalCollateralField) => {
+            let (provided, declared) = expect_two_fields(
+                sum.fields,
+                "IncorrectTotalCollateralField expects provided/declared",
+            )?;
+            Ok(ConwayUtxoPredicateFailure::IncorrectTotalCollateralField { provided, declared })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::BabbageOutputTooSmallUTxO) => {
+            let outputs =
+                expect_single_field(sum.fields, "BabbageOutputTooSmallUTxO expects payload")?;
+            Ok(ConwayUtxoPredicateFailure::BabbageOutputTooSmallUTxO { outputs })
+        }
+        Ok(ConwayUtxoPredicateFailureTag::BabbageNonDisjointRefInputs) => {
+            let overlapping =
+                expect_single_field(sum.fields, "BabbageNonDisjointRefInputs expects payload")?;
+            Ok(ConwayUtxoPredicateFailure::BabbageNonDisjointRefInputs { overlapping })
+        }
+        _ => Ok(ConwayUtxoPredicateFailure::Other(sum)),
+    }
+}
+
+fn parse_conway_utxos_failure(term: Term) -> Result<ConwayUtxosPredicateFailure, ParseError> {
+    let sum = TaggedSum::from_term(term).ok_or(ParseError::Malformed(
+        "utxos predicate failure must be a tagged sum",
+    ))?;
+
+    match ConwayUtxosPredicateFailureTag::try_from(sum.tag) {
+        Ok(ConwayUtxosPredicateFailureTag::ValidationTagMismatch) => {
+            let (tag, description) =
+                expect_two_fields(sum.fields, "ValidationTagMismatch expects tag/description")?;
+            Ok(ConwayUtxosPredicateFailure::ValidationTagMismatch { tag, description })
+        }
+        Ok(ConwayUtxosPredicateFailureTag::CollectErrors) => {
+            let errors = expect_single_field(sum.fields, "CollectErrors expects payload")?;
+            Ok(ConwayUtxosPredicateFailure::CollectErrors { errors })
+        }
+        _ => Ok(ConwayUtxosPredicateFailure::Other(sum)),
+    }
+}
+
+fn parse_conway_gov_cert_failure(term: Term) -> Result<ConwayGovCertPredicateFailure, ParseError> {
+    let sum = TaggedSum::from_term(term).ok_or(ParseError::Malformed(
+        "gov cert predicate failure must be a tagged sum",
+    ))?;
+
+    match ConwayGovCertPredicateFailureTag::try_from(sum.tag) {
+        Ok(ConwayGovCertPredicateFailureTag::ConwayDRepAlreadyRegistered) => {
+            let credential =
+                expect_single_field(sum.fields, "ConwayDRepAlreadyRegistered expects credential")?;
+            Ok(ConwayGovCertPredicateFailure::ConwayDRepAlreadyRegistered { credential })
+        }
+        Ok(ConwayGovCertPredicateFailureTag::ConwayDRepNotRegistered) => {
+            let credential =
+                expect_single_field(sum.fields, "ConwayDRepNotRegistered expects credential")?;
+            Ok(ConwayGovCertPredicateFailure::ConwayDRepNotRegistered { credential })
+        }
+        Ok(ConwayGovCertPredicateFailureTag::ConwayDRepIncorrectDeposit) => {
+            let mismatch =
+                expect_single_field(sum.fields, "ConwayDRepIncorrectDeposit expects mismatch")?;
+            Ok(ConwayGovCertPredicateFailure::ConwayDRepIncorrectDeposit { mismatch })
+        }
+        Ok(ConwayGovCertPredicateFailureTag::ConwayCommitteeHasPreviouslyResigned) => {
+            let cold_credential = expect_single_field(
+                sum.fields,
+                "ConwayCommitteeHasPreviouslyResigned expects credential",
+            )?;
+            Ok(
+                ConwayGovCertPredicateFailure::ConwayCommitteeHasPreviouslyResigned {
+                    cold_credential,
+                },
+            )
+        }
+        Ok(ConwayGovCertPredicateFailureTag::ConwayDRepIncorrectRefund) => {
+            let mismatch =
+                expect_single_field(sum.fields, "ConwayDRepIncorrectRefund expects mismatch")?;
+            Ok(ConwayGovCertPredicateFailure::ConwayDRepIncorrectRefund { mismatch })
+        }
+        Ok(ConwayGovCertPredicateFailureTag::ConwayCommitteeIsUnknown) => {
+            let cold_credential =
+                expect_single_field(sum.fields, "ConwayCommitteeIsUnknown expects credential")?;
+            Ok(ConwayGovCertPredicateFailure::ConwayCommitteeIsUnknown { cold_credential })
+        }
+        _ => Ok(ConwayGovCertPredicateFailure::Other(sum)),
+    }
+}
+
+fn parse_conway_gov_failure(term: Term) -> Result<ConwayGovPredicateFailure, ParseError> {
+    let sum = TaggedSum::from_term(term).ok_or(ParseError::Malformed(
+        "gov predicate failure must be a tagged sum",
+    ))?;
+
+    match ConwayGovPredicateFailureTag::try_from(sum.tag) {
+        Ok(ConwayGovPredicateFailureTag::GovActionsDoNotExist) => {
+            let missing =
+                expect_single_field(sum.fields, "GovActionsDoNotExist expects missing payload")?;
+            Ok(ConwayGovPredicateFailure::GovActionsDoNotExist { missing })
+        }
+        Ok(ConwayGovPredicateFailureTag::MalformedProposal) => {
+            let proposal =
+                expect_single_field(sum.fields, "MalformedProposal expects proposal payload")?;
+            Ok(ConwayGovPredicateFailure::MalformedProposal { proposal })
+        }
+        Ok(ConwayGovPredicateFailureTag::ProposalProcedureNetworkIdMismatch) => {
+            let (reward_account, expected_network) = expect_two_fields(
+                sum.fields,
+                "ProposalProcedureNetworkIdMismatch expects two payloads",
+            )?;
+            Ok(
+                ConwayGovPredicateFailure::ProposalProcedureNetworkIdMismatch {
+                    reward_account,
+                    expected_network,
+                },
+            )
+        }
+        Ok(ConwayGovPredicateFailureTag::TreasuryWithdrawalsNetworkIdMismatch) => {
+            let (offending_accounts, expected_network) = expect_two_fields(
+                sum.fields,
+                "TreasuryWithdrawalsNetworkIdMismatch expects two payloads",
+            )?;
+            Ok(
+                ConwayGovPredicateFailure::TreasuryWithdrawalsNetworkIdMismatch {
+                    offending_accounts,
+                    expected_network,
+                },
+            )
+        }
+        Ok(ConwayGovPredicateFailureTag::ProposalDepositIncorrect) => {
+            let mismatch = expect_single_field(
+                sum.fields,
+                "ProposalDepositIncorrect expects mismatch payload",
+            )?;
+            Ok(ConwayGovPredicateFailure::ProposalDepositIncorrect { mismatch })
+        }
+        Ok(ConwayGovPredicateFailureTag::DisallowedVoters) => {
+            let voters = expect_single_field(sum.fields, "DisallowedVoters expects payload")?;
+            Ok(ConwayGovPredicateFailure::DisallowedVoters { voters })
+        }
+        Ok(ConwayGovPredicateFailureTag::ConflictingCommitteeUpdate) => {
+            let members =
+                expect_single_field(sum.fields, "ConflictingCommitteeUpdate expects payload")?;
+            Ok(ConwayGovPredicateFailure::ConflictingCommitteeUpdate { members })
+        }
+        Ok(ConwayGovPredicateFailureTag::ExpirationEpochTooSmall) => {
+            let expired =
+                expect_single_field(sum.fields, "ExpirationEpochTooSmall expects payload")?;
+            Ok(ConwayGovPredicateFailure::ExpirationEpochTooSmall { expired })
+        }
+        Ok(ConwayGovPredicateFailureTag::InvalidPrevGovActionId) => {
+            let proposal = expect_single_field(
+                sum.fields,
+                "InvalidPrevGovActionId expects proposal payload",
+            )?;
+            Ok(ConwayGovPredicateFailure::InvalidPrevGovActionId { proposal })
+        }
+        Ok(ConwayGovPredicateFailureTag::VotingOnExpiredGovAction) => {
+            let votes =
+                expect_single_field(sum.fields, "VotingOnExpiredGovAction expects payload")?;
+            Ok(ConwayGovPredicateFailure::VotingOnExpiredGovAction { votes })
+        }
+        Ok(ConwayGovPredicateFailureTag::ProposalCantFollow) => {
+            let (previous, version_mismatch) =
+                expect_two_fields(sum.fields, "ProposalCantFollow expects two payloads")?;
+            Ok(ConwayGovPredicateFailure::ProposalCantFollow {
+                previous,
+                version_mismatch,
+            })
+        }
+        Ok(ConwayGovPredicateFailureTag::InvalidPolicyHash) => {
+            let (provided, expected) =
+                expect_two_fields(sum.fields, "InvalidPolicyHash expects two payloads")?;
+            Ok(ConwayGovPredicateFailure::InvalidPolicyHash { provided, expected })
+        }
+        Ok(ConwayGovPredicateFailureTag::DisallowedProposalDuringBootstrap) => {
+            let proposal = expect_single_field(
+                sum.fields,
+                "DisallowedProposalDuringBootstrap expects proposal",
+            )?;
+            Ok(ConwayGovPredicateFailure::DisallowedProposalDuringBootstrap { proposal })
+        }
+        Ok(ConwayGovPredicateFailureTag::DisallowedVotesDuringBootstrap) => {
+            let votes =
+                expect_single_field(sum.fields, "DisallowedVotesDuringBootstrap expects votes")?;
+            Ok(ConwayGovPredicateFailure::DisallowedVotesDuringBootstrap { votes })
+        }
+        Ok(ConwayGovPredicateFailureTag::VotersDoNotExist) => {
+            let voters = expect_single_field(sum.fields, "VotersDoNotExist expects payload")?;
+            Ok(ConwayGovPredicateFailure::VotersDoNotExist { voters })
+        }
+        Ok(ConwayGovPredicateFailureTag::ZeroTreasuryWithdrawals) => {
+            let action = expect_single_field(sum.fields, "ZeroTreasuryWithdrawals expects action")?;
+            Ok(ConwayGovPredicateFailure::ZeroTreasuryWithdrawals { action })
+        }
+        Ok(ConwayGovPredicateFailureTag::ProposalReturnAccountDoesNotExist) => {
+            let reward_account = expect_single_field(
+                sum.fields,
+                "ProposalReturnAccountDoesNotExist expects reward account",
+            )?;
+            Ok(ConwayGovPredicateFailure::ProposalReturnAccountDoesNotExist { reward_account })
+        }
+        Ok(ConwayGovPredicateFailureTag::TreasuryWithdrawalReturnAccountsDoNotExist) => {
+            let reward_accounts = expect_single_field(
+                sum.fields,
+                "TreasuryWithdrawalReturnAccountsDoNotExist expects accounts",
+            )?;
+            Ok(
+                ConwayGovPredicateFailure::TreasuryWithdrawalReturnAccountsDoNotExist {
+                    reward_accounts,
+                },
+            )
+        }
+        Ok(ConwayGovPredicateFailureTag::UnelectedCommitteeVoters) => {
+            let voters =
+                expect_single_field(sum.fields, "UnelectedCommitteeVoters expects payload")?;
+            Ok(ConwayGovPredicateFailure::UnelectedCommitteeVoters { voters })
+        }
+        _ => Ok(ConwayGovPredicateFailure::Other(sum)),
+    }
+}
+
+fn parse_conway_certs_failure(term: Term) -> Result<ConwayCertsPredicateFailure, ParseError> {
+    let sum = TaggedSum::from_term(term).ok_or(ParseError::Malformed(
+        "certs predicate failure must be a tagged sum",
+    ))?;
+
+    match ConwayCertsPredicateFailureTag::try_from(sum.tag) {
+        Ok(ConwayCertsPredicateFailureTag::WithdrawalsNotInRewardsCERTS) => {
+            let withdrawals = expect_single_field(
+                sum.fields,
+                "WithdrawalsNotInRewardsCERTS expects withdrawals payload",
+            )?;
+            Ok(ConwayCertsPredicateFailure::WithdrawalsNotInRewardsCERTS { withdrawals })
+        }
+        Ok(ConwayCertsPredicateFailureTag::CertFailure) => {
+            let child = expect_single_field(sum.fields, "CertFailure expects a single payload")?;
+            let cert = parse_conway_cert_failure(child)?;
+            Ok(ConwayCertsPredicateFailure::CertFailure(Box::new(cert)))
+        }
+        _ => Ok(ConwayCertsPredicateFailure::Other(sum)),
+    }
+}
+
+fn parse_conway_cert_failure(term: Term) -> Result<ConwayCertPredicateFailure, ParseError> {
+    let sum = TaggedSum::from_term(term).ok_or(ParseError::Malformed(
+        "certificate predicate failure must be a tagged sum",
+    ))?;
+
+    match ConwayCertPredicateFailureTag::try_from(sum.tag) {
+        Ok(ConwayCertPredicateFailureTag::DelegFailure) => {
+            let child = expect_single_field(sum.fields, "DelegFailure expects a single payload")?;
+            let deleg = parse_conway_deleg_failure(child)?;
+            Ok(ConwayCertPredicateFailure::DelegFailure(Box::new(deleg)))
+        }
+        Ok(ConwayCertPredicateFailureTag::PoolFailure) => {
+            let failure = expect_single_field(sum.fields, "PoolFailure expects a single payload")?;
+            Ok(ConwayCertPredicateFailure::PoolFailure { failure })
+        }
+        Ok(ConwayCertPredicateFailureTag::GovCertFailure) => {
+            let child = expect_single_field(sum.fields, "GovCertFailure expects a single payload")?;
+            let gov = parse_conway_gov_cert_failure(child)?;
+            Ok(ConwayCertPredicateFailure::GovCertFailure(Box::new(gov)))
+        }
+        _ => Ok(ConwayCertPredicateFailure::Other(sum)),
+    }
+}
+
+fn parse_conway_deleg_failure(term: Term) -> Result<ConwayDelegPredicateFailure, ParseError> {
+    let sum = TaggedSum::from_term(term).ok_or(ParseError::Malformed(
+        "deleg predicate failure must be a tagged sum",
+    ))?;
+
+    match ConwayDelegPredicateFailureTag::try_from(sum.tag) {
+        Ok(ConwayDelegPredicateFailureTag::IncorrectDepositDELEG) => {
+            let deposit =
+                expect_single_field(sum.fields, "IncorrectDeposit expects a deposit payload")?;
+            Ok(ConwayDelegPredicateFailure::IncorrectDeposit { deposit })
+        }
+        Ok(ConwayDelegPredicateFailureTag::StakeKeyRegisteredDELEG) => {
+            let stake_credential = expect_single_field(
+                sum.fields,
+                "StakeKeyRegistered expects a credential payload",
+            )?;
+            Ok(ConwayDelegPredicateFailure::StakeKeyRegistered { stake_credential })
+        }
+        Ok(ConwayDelegPredicateFailureTag::StakeKeyNotRegisteredDELEG) => {
+            let stake_credential = expect_single_field(
+                sum.fields,
+                "StakeKeyNotRegistered expects a credential payload",
+            )?;
+            Ok(ConwayDelegPredicateFailure::StakeKeyNotRegistered { stake_credential })
+        }
+        Ok(ConwayDelegPredicateFailureTag::StakeKeyHasNonZeroRewardAccountBalanceDELEG) => {
+            let balance = expect_single_field(
+                sum.fields,
+                "StakeKeyHasNonZeroRewardAccountBalance expects a balance",
+            )?;
+            Ok(ConwayDelegPredicateFailure::StakeKeyHasNonZeroRewardAccountBalance { balance })
+        }
+        Ok(ConwayDelegPredicateFailureTag::DelegateeDRepNotRegisteredDELEG) => {
+            let delegatee = expect_single_field(
+                sum.fields,
+                "DelegateeDRepNotRegistered expects a credential",
+            )?;
+            Ok(ConwayDelegPredicateFailure::DelegateeDRepNotRegistered { delegatee })
+        }
+        Ok(ConwayDelegPredicateFailureTag::DelegateeStakePoolNotRegisteredDELEG) => {
+            let delegatee_term = expect_single_field(
+                sum.fields,
+                "DelegateeStakePoolNotRegistered expects one argument",
+            )?;
+            let delegatee = extract_bytes(delegatee_term)?;
+            Ok(ConwayDelegPredicateFailure::DelegateeStakePoolNotRegistered { delegatee })
+        }
+        Ok(ConwayDelegPredicateFailureTag::DepositIncorrectDELEG) => {
+            let mismatch =
+                expect_single_field(sum.fields, "DepositIncorrect expects mismatch payload")?;
+            Ok(ConwayDelegPredicateFailure::DepositIncorrect { mismatch })
+        }
+        Ok(ConwayDelegPredicateFailureTag::RefundIncorrectDELEG) => {
+            let mismatch =
+                expect_single_field(sum.fields, "RefundIncorrect expects mismatch payload")?;
+            Ok(ConwayDelegPredicateFailure::RefundIncorrect { mismatch })
+        }
+        _ => Ok(ConwayDelegPredicateFailure::Other(sum)),
+    }
+}
+
+fn extract_bytes(mut term: Term) -> Result<Vec<u8>, ParseError> {
+    loop {
+        term = match term {
+            Term::Bytes(bytes) => return Ok(bytes),
+            Term::Array(mut items) if items.len() == 1 => items.remove(0),
+            Term::Tagged(_, boxed) => *boxed,
+            _ => return Err(ParseError::Malformed("expected byte string payload")),
+        };
+    }
+}
+
+fn expect_fields(
+    mut fields: Vec<Term>,
+    expected: usize,
+    context: &'static str,
+) -> Result<Vec<Term>, ParseError> {
+    if fields.len() != expected {
+        return Err(ParseError::Malformed(context));
+    }
+    Ok(fields)
+}
+
+fn expect_single_field(fields: Vec<Term>, context: &'static str) -> Result<Term, ParseError> {
+    let mut fields = expect_fields(fields, 1, context)?;
+    Ok(fields.remove(0))
+}
+
+fn expect_two_fields(fields: Vec<Term>, context: &'static str) -> Result<(Term, Term), ParseError> {
+    let mut fields = expect_fields(fields, 2, context)?;
+    let first = fields.remove(0);
+    let second = fields.remove(0);
+    Ok((first, second))
+}
+
+fn expect_no_fields(fields: Vec<Term>, context: &'static str) -> Result<(), ParseError> {
+    if fields.is_empty() {
+        Ok(())
+    } else {
+        Err(ParseError::Malformed(context))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ciborium::ser::into_writer;
+    use ciborium::value::Integer;
+
+    #[test]
+    fn round_trip_simple_sum() {
+        let mut buffer = Vec::new();
+        // Encode a dummy predicate failure represented as [5, [1], "payload"].
+        let message = Value::Array(vec![
+            Value::Integer(Integer::from(5u64)),
+            Value::Array(vec![Value::Integer(Integer::from(1u64))]),
+            Value::Text("payload".into()),
+        ]);
+        into_writer(&message, &mut buffer).expect("encode test value");
+
+        let tree = decode_predicate_failure_bytes(&buffer).expect("parse tree");
+        match tree {
+            TaggedTree::Sum(sum, children) => {
+                assert_eq!(sum.tag, 5);
+                assert_eq!(children.len(), 2);
+            }
+            TaggedTree::Leaf(_) => panic!("expected a sum"),
+        }
+    }
+
+    #[test]
+    fn parse_conway_delegatee_stake_pool_not_registered() {
+        let bytes = hex_to_bytes(
+            "82028182068182018202d9010281581cda79a7527e856e5e1b1653c6c8e1255f79d8fe38b7e0a97bb5d0872c",
+        );
+        let failures =
+            decode_conway_ledger_failures_bytes(&bytes).expect("decode Conway ledger failures");
+        assert_eq!(failures.len(), 1);
+
+        match &failures[0] {
+            ConwayLedgerPredicateFailure::CertsFailure(certs) => match &**certs {
+                ConwayCertsPredicateFailure::CertFailure(cert) => match &**cert {
+                    ConwayCertPredicateFailure::DelegFailure(deleg) => match deleg {
+                        ConwayDelegPredicateFailure::DelegateeStakePoolNotRegistered {
+                            delegatee,
+                        } => {
+                            assert_eq!(
+                                delegatee,
+                                &hex_to_bytes(
+                                    "da79a7527e856e5e1b1653c6c8e1255f79d8fe38b7e0a97bb5d0872c",
+                                )
+                            );
+                        }
+                        other => panic!("unexpected deleg predicate failure: {:?}", other),
+                    },
+                    other => panic!("unexpected certificate predicate failure: {:?}", other),
+                },
+                other => panic!("unexpected certs predicate failure: {:?}", other),
+            },
+            other => panic!("unexpected ledger predicate failure: {:?}", other),
+        }
+    }
+
+    fn hex_to_bytes(hex: &str) -> Vec<u8> {
+        let mut out = Vec::with_capacity(hex.len() / 2);
+        for chunk in hex.as_bytes().chunks(2) {
+            let hi = (chunk[0] as char).to_digit(16).expect("upper nibble") as u8;
+            let lo = (chunk[1] as char).to_digit(16).expect("lower nibble") as u8;
+            out.push((hi << 4) | lo);
+        }
+        out
+    }
+}

--- a/docs/rust_rule_errors.rs
+++ b/docs/rust_rule_errors.rs
@@ -1,0 +1,1546 @@
+//! Rust representations of STS predicate failure types extracted from the
+//! Cardano ledger `Rules` modules across eras.
+//!
+//! NOTE: These definitions focus on the structure and CBOR tags of the
+//! predicate failure enums. Domain-specific payload types are represented by
+//! lightweight stand-ins so the relationships between failures remain clear.
+//! Any field marked with `TODO` should be replaced with the concrete type when
+//! wiring these definitions into real code.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+// ---------------------------------------------------------------------------
+// Helper stand-ins
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Coin(pub u64); // `coin = uint` in the CDDL specs.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct DeltaCoin(pub i64); // `delta_coin = int` in the CDDL specs.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct SlotNo(pub u64); // `slot_no = uint .size 8`.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct EpochNo(pub u64); // `epoch_no = uint .size 8`.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct NetworkId(pub u8); // `network_id = 0 / 1`.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Address(pub Vec<u8>); // `address = bytes` with format described in the CDDL.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct RewardAccount(pub Vec<u8>); // `reward_account = bytes`.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Hash28(pub [u8; 28]);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Hash32(pub [u8; 32]);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ScriptHash(pub Hash28); // `script_hash = hash28`.
+
+pub type PolicyId = ScriptHash; // `policy_id = script_hash`.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct DataHash(pub Hash32); // Various datum hashes use 32-byte hashes.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ScriptIntegrityHash(pub Hash32); // Matches the 32-byte hash usage.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct TxAuxDataHash(pub Hash32); // `auxiliary_data_hash = hash32`.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct TxId(pub Hash32); // `transaction_id = hash32`.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct TxIx(pub u16); // `transaction_input = [tx_id, index : uint .size 2]`.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct TxIn {
+    pub transaction_id: TxId,
+    pub index: TxIx,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ProtVer {
+    pub major: u16, // `major_protocol_version = 0 .. 12`.
+    pub minor: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ExUnits {
+    pub mem: u64,
+    pub steps: u64,
+} // `ex_units = [mem : uint, steps : uint]`.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ValidityInterval {
+    pub invalid_before: Option<SlotNo>,
+    pub invalid_hereafter: Option<SlotNo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum MIRPot {
+    #[default]
+    Reserves,
+    Treasury,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct UnitInterval {
+    pub numerator: u64,
+    pub denominator: u64,
+}
+
+impl UnitInterval {
+    pub const HALF: UnitInterval = UnitInterval {
+        numerator: 1,
+        denominator: 2,
+    };
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct NonNegativeInterval {
+    pub numerator: u64,
+    pub denominator: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct EpochInterval(pub u32); // `epoch_interval = uint .size 4`.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct AddrKeyHash(pub Hash28);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct KeyHash(pub Hash28);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct PoolKeyHash(pub Hash28);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct VRFKeyHash(pub Hash32);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct VerificationKey(pub [u8; 32]); // `vkey = bytes .size 32`.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Credential {
+    KeyHash(AddrKeyHash),
+    ScriptHash(ScriptHash),
+}
+
+impl Default for Credential {
+    fn default() -> Self {
+        Credential::KeyHash(AddrKeyHash(Hash28([0; 28])))
+    }
+}
+
+pub type StakeCredential = Credential;
+pub type CommitteeColdCredential = Credential;
+pub type CommitteeHotCredential = Credential;
+pub type DRepCredential = Credential;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DRep {
+    KeyHash(AddrKeyHash),
+    ScriptHash(ScriptHash),
+    Abstain,
+    NoConfidence,
+}
+
+impl Default for DRep {
+    fn default() -> Self {
+        DRep::Abstain
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Anchor {
+    pub url: String,
+    pub data_hash: Hash32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct PoolMetadata {
+    pub url: String,
+    pub metadata_hash: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum Relay {
+    SingleHostAddr {
+        port: Option<u16>,
+        ipv4: Option<[u8; 4]>,
+        ipv6: Option<[u8; 16]>,
+    },
+    SingleHostName {
+        port: Option<u16>,
+        dns_name: String,
+    },
+    MultiHostName {
+        dns_name: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct PoolParams {
+    pub operator: PoolKeyHash,
+    pub vrf_keyhash: VRFKeyHash,
+    pub pledge: Coin,
+    pub cost: Coin,
+    pub margin: UnitInterval,
+    pub reward_account: RewardAccount,
+    pub owners: BTreeSet<AddrKeyHash>,
+    pub relays: Vec<Relay>,
+    pub metadata: Option<PoolMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PoolCert {
+    StakeRegistration { credential: StakeCredential },
+    StakeDeregistration { credential: StakeCredential },
+    StakeDelegation { credential: StakeCredential, pool: PoolKeyHash },
+    PoolRegistration { params: PoolParams },
+    PoolRetirement { pool: PoolKeyHash, epoch: EpochNo },
+    RegCert { credential: StakeCredential, coin: Coin },
+    UnregCert { credential: StakeCredential, coin: Coin },
+    VoteDelegCert { credential: StakeCredential, drep: DRep },
+    StakeVoteDelegCert { credential: StakeCredential, pool: PoolKeyHash, drep: DRep },
+    StakeRegDelegCert { credential: StakeCredential, pool: PoolKeyHash, deposit: Coin },
+    VoteRegDelegCert { credential: StakeCredential, drep: DRep, deposit: Coin },
+    StakeVoteRegDelegCert {
+        credential: StakeCredential,
+        pool: PoolKeyHash,
+        drep: DRep,
+        deposit: Coin,
+    },
+    AuthCommitteeHotCert {
+        cold: CommitteeColdCredential,
+        hot: CommitteeHotCredential,
+    },
+    ResignCommitteeColdCert {
+        cold: CommitteeColdCredential,
+        anchor: Option<Anchor>,
+    },
+    RegDRepCert {
+        credential: DRepCredential,
+        deposit: Coin,
+        anchor: Option<Anchor>,
+    },
+    UnregDRepCert {
+        credential: DRepCredential,
+        deposit: Coin,
+    },
+    UpdateDRepCert {
+        credential: DRepCredential,
+        anchor: Option<Anchor>,
+    },
+}
+
+impl Default for PoolCert {
+    fn default() -> Self {
+        PoolCert::StakeRegistration {
+            credential: StakeCredential::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Withdrawals(pub BTreeMap<RewardAccount, Coin>); // `withdrawals = {+ reward_account => coin}`.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct AssetName(pub Vec<u8>); // `asset_name = bytes .size (0 .. 32)`.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct MultiAsset(pub BTreeMap<PolicyId, BTreeMap<AssetName, u64>>);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ValueStruct {
+    Coin(Coin),
+    MultiAsset { coin: Coin, assets: MultiAsset },
+}
+
+impl Default for ValueStruct {
+    fn default() -> Self {
+        ValueStruct::Coin(Coin(0))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct BoundedBytes(pub Vec<u8>); // `bounded_bytes = bytes .size (0 .. 64)`.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BigInt {
+    Int(i128),
+    BigUInt(BoundedBytes),
+    BigNInt(BoundedBytes),
+}
+
+impl Default for BigInt {
+    fn default() -> Self {
+        BigInt::Int(0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PlutusData {
+    Constr { tag: u32, fields: Vec<PlutusData> },
+    Map(BTreeMap<PlutusData, PlutusData>),
+    List(Vec<PlutusData>),
+    Integer(BigInt),
+    Bytes(Vec<u8>),
+}
+
+impl Default for PlutusData {
+    fn default() -> Self {
+        PlutusData::Integer(BigInt::default())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DatumOption {
+    Hash(DataHash),
+    Inline(PlutusData),
+}
+
+impl Default for DatumOption {
+    fn default() -> Self {
+        DatumOption::Hash(DataHash(Hash32([0; 32])))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NativeScript {
+    ScriptPubkey(AddrKeyHash),
+    ScriptAll(Vec<NativeScript>),
+    ScriptAny(Vec<NativeScript>),
+    ScriptNOfK { required: i64, scripts: Vec<NativeScript> },
+    InvalidBefore(SlotNo),
+    InvalidHereafter(SlotNo),
+}
+
+impl Default for NativeScript {
+    fn default() -> Self {
+        NativeScript::ScriptPubkey(AddrKeyHash(Hash28([0; 28])))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PlutusScript {
+    V1(Vec<u8>),
+    V2(Vec<u8>),
+    V3(Vec<u8>),
+}
+
+impl Default for PlutusScript {
+    fn default() -> Self {
+        PlutusScript::V1(vec![])
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Script {
+    Native(NativeScript),
+    Plutus(PlutusScript),
+}
+
+impl Default for Script {
+    fn default() -> Self {
+        Script::Native(NativeScript::default())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ScriptRef(pub Script);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TxOutStruct {
+    Shelley {
+        address: Address,
+        amount: ValueStruct,
+        datum_hash: Option<DataHash>,
+    },
+    Babbage {
+        address: Address,
+        amount: ValueStruct,
+        datum_option: Option<DatumOption>,
+        script_ref: Option<ScriptRef>,
+    },
+}
+
+impl Default for TxOutStruct {
+    fn default() -> Self {
+        TxOutStruct::Shelley {
+            address: Address::default(),
+            amount: ValueStruct::default(),
+            datum_hash: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct UTxOStruct(pub BTreeMap<TxIn, TxOutStruct>);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct VotingProcedure {
+    pub vote: u8, // `vote = 0 .. 2`
+    pub anchor: Option<Anchor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum VoterEnum {
+    CommitteeKey(AddrKeyHash),
+    CommitteeScript(ScriptHash),
+    DRepKey(AddrKeyHash),
+    DRepScript(ScriptHash),
+    StakePool(PoolKeyHash),
+}
+
+impl Default for VoterEnum {
+    fn default() -> Self {
+        VoterEnum::DRepKey(AddrKeyHash(Hash28([0; 28])))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct VotingProceduresStruct(
+    pub BTreeMap<VoterEnum, BTreeMap<GovActionId, VotingProcedure>>,
+);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ProposalProcedureStruct {
+    pub deposit: Coin,
+    pub reward_account: RewardAccount,
+    pub action: GovActionStruct,
+    pub anchor: Anchor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Constitution {
+    pub anchor: Anchor,
+    pub script_hash: Option<ScriptHash>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct CostModels(pub BTreeMap<u8, Vec<i64>>);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ExUnitPrices {
+    pub mem_price: NonNegativeInterval,
+    pub step_price: NonNegativeInterval,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct PoolVotingThresholds {
+    pub motion_no_confidence: UnitInterval,
+    pub committee_normal: UnitInterval,
+    pub committee_no_confidence: UnitInterval,
+    pub hard_fork_initiation: UnitInterval,
+    pub security_parameter: UnitInterval,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct DRepVotingThresholds {
+    pub motion_no_confidence: UnitInterval,
+    pub committee_normal: UnitInterval,
+    pub committee_no_confidence: UnitInterval,
+    pub update_constitution: UnitInterval,
+    pub hard_fork_initiation: UnitInterval,
+    pub pparam_network: UnitInterval,
+    pub pparam_economic: UnitInterval,
+    pub pparam_technical: UnitInterval,
+    pub pparam_governance: UnitInterval,
+    pub treasury_withdrawal: UnitInterval,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ProtocolParamUpdate {
+    pub minfee_a: Option<Coin>,
+    pub minfee_b: Option<Coin>,
+    pub max_block_body_size: Option<u32>,
+    pub max_tx_size: Option<u32>,
+    pub max_block_header_size: Option<u16>,
+    pub key_deposit: Option<Coin>,
+    pub pool_deposit: Option<Coin>,
+    pub max_epoch: Option<EpochInterval>,
+    pub desired_number_of_pools: Option<u16>,
+    pub pool_pledge_influence: Option<NonNegativeInterval>,
+    pub expansion_rate: Option<UnitInterval>,
+    pub treasury_growth_rate: Option<UnitInterval>,
+    pub min_pool_cost: Option<Coin>,
+    pub ada_per_utxo_byte: Option<Coin>,
+    pub cost_models: Option<CostModels>,
+    pub ex_unit_prices: Option<ExUnitPrices>,
+    pub max_tx_ex_units: Option<ExUnits>,
+    pub max_block_ex_units: Option<ExUnits>,
+    pub max_value_size: Option<u32>,
+    pub collateral_percentage: Option<u16>,
+    pub max_collateral_inputs: Option<u16>,
+    pub pool_voting_thresholds: Option<PoolVotingThresholds>,
+    pub drep_voting_thresholds: Option<DRepVotingThresholds>,
+    pub min_committee_size: Option<u16>,
+    pub committee_term_limit: Option<EpochInterval>,
+    pub governance_action_validity_period: Option<EpochInterval>,
+    pub governance_action_deposit: Option<Coin>,
+    pub drep_deposit: Option<Coin>,
+    pub drep_inactivity_period: Option<EpochInterval>,
+    pub ref_script_coins_per_byte: Option<NonNegativeInterval>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct GovActionId {
+    pub tx_id: TxId,
+    pub action_index: GovActionIx,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum GovActionStruct {
+    ParameterChange {
+        previous: Option<GovPurposeIdStruct>,
+        update: ProtocolParamUpdate,
+        policy_hash: Option<ScriptHash>,
+    },
+    HardForkInitiation {
+        previous: Option<GovPurposeIdStruct>,
+        protocol_version: ProtVer,
+    },
+    TreasuryWithdrawals {
+        withdrawals: BTreeMap<RewardAccount, Coin>,
+        policy_hash: Option<ScriptHash>,
+    },
+    NoConfidence {
+        previous: Option<GovPurposeIdStruct>,
+    },
+    UpdateCommittee {
+        previous: Option<GovPurposeIdStruct>,
+        removals: BTreeSet<CommitteeColdCredential>,
+        additions: BTreeMap<CommitteeColdCredential, EpochNo>,
+        new_quorum: UnitInterval,
+    },
+    NewConstitution {
+        previous: Option<GovPurposeIdStruct>,
+        constitution: Constitution,
+    },
+    InfoAction,
+}
+
+impl Default for GovActionStruct {
+    fn default() -> Self {
+        GovActionStruct::InfoAction
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum GovActionPurpose {
+    ParameterChange,
+    HardFork,
+    Committee,
+    Constitution,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct GovPurposeIdStruct {
+    pub purpose: GovActionPurpose,
+    pub id: GovActionId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum RedeemerTag {
+    Spend,
+    Mint,
+    Cert,
+    Reward,
+    Voting,
+    Proposing,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct PlutusPurposeStruct {
+    pub tag: RedeemerTag,
+    pub index: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct GovEnvStruct;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelationKind {
+    Eq,
+    Lteq,
+    Gteq,
+    Lt,
+    Gt,
+    Subset,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelationMismatch<T> {
+    pub relation: RelationKind,
+    pub supplied: T,
+    pub expected: T,
+}
+
+pub type StrictMaybe<T> = Option<T>;
+pub type Natural = u64;
+pub type Word32 = u32;
+pub type ByteString = Vec<u8>;
+pub type TagMismatchDescription = String;
+pub type IsValid = bool;
+pub type Text = String;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct NonEmpty<T>(pub Vec<T>); // TODO: enforce the invariant.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct GovActionIx(pub u16);
+
+pub type TxOut<Era> = TxOutStruct;
+pub type Value<Era> = ValueStruct;
+pub type UTxO<Era> = UTxOStruct;
+pub type GovAction<Era> = GovActionStruct;
+pub type ProposalProcedure<Era> = ProposalProcedureStruct;
+pub type VotingProcedures<Era> = VotingProceduresStruct;
+pub type GovEnv<Era> = GovEnvStruct;
+pub type Voter = VoterEnum;
+pub type GovPurposeId<Purpose> = GovPurposeIdStruct;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct HardForkPurpose;
+
+pub type PlutusPurpose<Tag, Era> = PlutusPurposeStruct;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct AsItem;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct AsIx;
+
+pub type Mismatch<Relation, T> = RelationMismatch<T>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct RelEQ;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct RelLTEQ;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct RelGTEQ;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct RelLT;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct RelGT;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct RelSubset;
+
+// ---------------------------------------------------------------------------
+// Shelley era predicate failures
+// ---------------------------------------------------------------------------
+
+pub mod shelley {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum VotingPeriod {
+        /// Tag: 0
+        VoteForThisEpoch,
+        /// Tag: 1
+        VoteForNextEpoch,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum PpupPredicateFailure {
+        /// Tag: 0
+        NonGenesisUpdatePPUP {
+            offending_keys: Mismatch<RelSubset, BTreeSet<KeyHash>>,
+        },
+        /// Tag: 1
+        PPUpdateWrongEpoch {
+            current_epoch: EpochNo,
+            declared_epoch: EpochNo,
+            voting_period: VotingPeriod,
+        },
+        /// Tag: 2
+        PVCannotFollowPPUP {
+            proposed_version: ProtVer,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum UtxoPredicateFailure<Era> {
+        /// Tag: 0
+        BadInputsUTxO {
+            invalid_inputs: BTreeSet<TxIn>,
+        },
+        /// Tag: 1
+        ExpiredUTxO {
+            current_slot: SlotNo,
+        },
+        /// Tag: 2
+        MaxTxSizeUTxO {
+            size_mismatch: Mismatch<RelLTEQ, usize>,
+        },
+        /// Tag: 3
+        InputSetEmptyUTxO,
+        /// Tag: 4
+        FeeTooSmallUTxO {
+            fee_mismatch: Mismatch<RelGTEQ, Coin>,
+        },
+        /// Tag: 5
+        ValueNotConservedUTxO {
+            balance_mismatch: Mismatch<RelEQ, Value<Era>>,
+        },
+        /// Tag: 6
+        OutputTooSmallUTxO {
+            tiny_outputs: Vec<TxOut<Era>>,
+        },
+        /// Tag: 7
+        UpdateFailure(super::shelley::PpupPredicateFailure),
+        /// Tag: 8
+        WrongNetwork {
+            expected: NetworkId,
+            offending: BTreeSet<Address>,
+        },
+        /// Tag: 9
+        WrongNetworkWithdrawal {
+            expected: NetworkId,
+            offending: BTreeSet<RewardAccount>,
+        },
+        /// Tag: 10
+        OutputBootAddrAttrsTooBig {
+            oversized_bootstrap_outputs: Vec<TxOut<Era>>,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum UtxowPredicateFailure<Era> {
+        /// Tag: 0
+        InvalidWitnessesUTXOW {
+            invalid_witnesses: Vec<Credential>,
+        },
+        /// Tag: 1
+        MissingVKeyWitnessesUTXOW {
+            missing_signers: BTreeSet<KeyHash>,
+        },
+        /// Tag: 2
+        MissingScriptWitnessesUTXOW {
+            missing_scripts: BTreeSet<ScriptHash>,
+        },
+        /// Tag: 3
+        ScriptWitnessNotValidatingUTXOW {
+            failed_scripts: BTreeSet<ScriptHash>,
+        },
+        /// Tag: 4
+        UtxoFailure(super::shelley::UtxoPredicateFailure<Era>),
+        /// Tag: 5
+        MIRInsufficientGenesisSigsUTXOW {
+            missing_signatures: BTreeSet<KeyHash>,
+        },
+        /// Tag: 6
+        MissingTxBodyMetadataHash {
+            expected: TxAuxDataHash,
+        },
+        /// Tag: 7
+        MissingTxMetadata {
+            referenced: TxAuxDataHash,
+        },
+        /// Tag: 8
+        ConflictingMetadataHash {
+            mismatch: Mismatch<RelEQ, TxAuxDataHash>,
+        },
+        /// Tag: 9
+        InvalidMetadata,
+        /// Tag: 10
+        ExtraneousScriptWitnessesUTXOW {
+            extra_scripts: BTreeSet<ScriptHash>,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum DelegPredicateFailure {
+        /// Tag: 0
+        StakeKeyAlreadyRegistered {
+            credential: Credential,
+        },
+        /// Tag: 1
+        StakeKeyNotRegistered {
+            credential: Credential,
+        },
+        /// Tag: 2
+        StakeKeyNonZeroAccountBalance {
+            remaining_balance: Coin,
+        },
+        /// Tag: 3
+        StakeDelegationImpossible {
+            credential: Credential,
+        },
+        /// Tag: 4
+        WrongCertificateType,
+        /// Tag: 5
+        GenesisKeyNotInMapping {
+            genesis_key: KeyHash,
+        },
+        /// Tag: 6
+        DuplicateGenesisDelegate {
+            delegate: KeyHash,
+        },
+        /// Tag: 7
+        InsufficientForInstantaneousRewards {
+            pot: MIRPot,
+            bound: Mismatch<RelLTEQ, Coin>,
+        },
+        /// Tag: 8
+        MIRCertificateTooLateInEpoch {
+            cutoff: Mismatch<RelLT, SlotNo>,
+        },
+        /// Tag: 9
+        DuplicateGenesisVRF {
+            vrf: VRFKeyHash,
+        },
+        /// Tag: 11
+        MIRTransferNotCurrentlyAllowed,
+        /// Tag: 12
+        MIRNegativesNotCurrentlyAllowed,
+        /// Tag: 13
+        InsufficientForTransfer {
+            pot: MIRPot,
+            bound: Mismatch<RelLTEQ, Coin>,
+        },
+        /// Tag: 14
+        MIRProducesNegativeUpdate,
+        /// Tag: 15
+        MIRNegativeTransfer {
+            pot: MIRPot,
+            attempted: Coin,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum PoolPredicateFailure {
+        /// Tag: 0
+        StakePoolNotRegisteredOnKey {
+            pool_id: KeyHash,
+        },
+        /// Tag: 1
+        StakePoolRetirementWrongEpoch {
+            retirement_too_early: Mismatch<RelGT, EpochNo>,
+            retirement_too_late: Mismatch<RelLTEQ, EpochNo>,
+        },
+        /// Tag: 3
+        StakePoolCostTooLow {
+            cost_bound: Mismatch<RelGTEQ, Coin>,
+        },
+        /// Tag: 4
+        WrongNetwork {
+            network_mismatch: Mismatch<RelEQ, NetworkId>,
+            pool_id: KeyHash,
+        },
+        /// Tag: 5
+        PoolMetadataHashTooBig {
+            pool_id: KeyHash,
+            hash_size: usize,
+        },
+        /// Tag: 6
+        VRFKeyHashAlreadyRegistered {
+            pool_id: KeyHash,
+            vrf: VRFKeyHash,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum DelegsPredicateFailure<Era> {
+        /// Tag: 0
+        DelegateeNotRegistered {
+            pool_id: KeyHash,
+        },
+        /// Tag: 1
+        WithdrawalsNotInRewards {
+            withdrawals: Withdrawals,
+        },
+        /// Tag: 2
+        DelplFailure(DelplPredicateFailure<Era>),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum DelplPredicateFailure<Era> {
+        /// Tag: 0
+        PoolFailure(PoolPredicateFailure),
+        /// Tag: 1
+        DelegFailure(DelegPredicateFailure),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum LedgerPredicateFailure<Era> {
+        /// Tag: 0
+        UtxowFailure(UtxowPredicateFailure<Era>),
+        /// Tag: 1
+        DelegsFailure(DelegsPredicateFailure<Era>),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum BbodyPredicateFailure<Era> {
+        // No explicit CBOR instance in the source; tags unknown.
+        WrongBlockBodySizeBBODY {
+            mismatch: Mismatch<RelEQ, usize>,
+        },
+        InvalidBodyHashBBODY {
+            mismatch: Mismatch<RelEQ, [u8; 32]>, // TODO: real hash type
+        },
+        LedgersFailure(LedgersPredicateFailure<Era>),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum LedgersPredicateFailure<Era> {
+        /// Tag 0 relayed through `ShelleyBbodyPredFailure`
+        LedgersFailure(LedgerPredicateFailure<Era>),
+        /// TODO: capture other constructors when serialisation is required.
+    }
+
+    // TODO: Mirror the remaining Shelley-era failures (e.g. MIR, TICK) if
+    // serialisation details become relevant.
+}
+
+// ---------------------------------------------------------------------------
+// Allegra & Mary era predicate failures
+// ---------------------------------------------------------------------------
+
+pub mod allegra {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum UtxoPredicateFailure<Era> {
+        /// Tag: 0 (mirrors Shelley via translation layer)
+        AlonzoWrapped(super::alonzo::UtxoPredicateFailure<Era>),
+        /// Tag: 1
+        ValidateOutsideValidityInterval {
+            interval: ValidityInterval,
+        },
+        // TODO: complete once allegra-specific constructors are required.
+    }
+
+    // Mary reuses Allegra failures; see the `mary` module for explicit aliases.
+}
+
+pub mod mary {
+    use super::*;
+
+    pub type UtxoPredicateFailure<Era> = super::allegra::UtxoPredicateFailure<Era>;
+}
+
+// ---------------------------------------------------------------------------
+// Alonzo era predicate failures
+// ---------------------------------------------------------------------------
+
+pub mod alonzo {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum BbodyPredicateFailure<Era> {
+        /// Tag: 0
+        ShelleyInAlonzo(super::shelley::BbodyPredicateFailure<Era>),
+        /// Tag: 1
+        TooManyExUnits {
+            bound: Mismatch<RelLTEQ, ExUnits>,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum UtxoPredicateFailure<Era> {
+        /// Tag: 0
+        BadInputsUTxO {
+            invalid_inputs: BTreeSet<TxIn>,
+        },
+        /// Tag: 1
+        OutsideValidityIntervalUTxO {
+            interval: ValidityInterval,
+            current_slot: SlotNo,
+        },
+        /// Tag: 2
+        MaxTxSizeUTxO {
+            bound: Mismatch<RelLTEQ, u32>,
+        },
+        /// Tag: 3
+        InputSetEmptyUTxO,
+        /// Tag: 4
+        FeeTooSmallUTxO {
+            bound: Mismatch<RelGTEQ, Coin>,
+        },
+        /// Tag: 5
+        ValueNotConservedUTxO {
+            mismatch: Mismatch<RelEQ, Value<Era>>,
+        },
+        /// Tag: 6
+        OutputTooSmallUTxO {
+            outputs: Vec<TxOut<Era>>,
+        },
+        /// Tag: 7
+        UtxosFailure(UtxosPredicateFailure<Era>),
+        /// Tag: 8
+        WrongNetwork {
+            expected: NetworkId,
+            offending: BTreeSet<Address>,
+        },
+        /// Tag: 9
+        WrongNetworkWithdrawal {
+            expected: NetworkId,
+            offending: BTreeSet<RewardAccount>,
+        },
+        /// Tag: 10
+        OutputBootAddrAttrsTooBig {
+            outputs: Vec<TxOut<Era>>,
+        },
+        /// Tag: 12
+        OutputTooBigUTxO {
+            oversized_outputs: Vec<(i32, i32, TxOut<Era>)>,
+        },
+        /// Tag: 13
+        InsufficientCollateral {
+            computed: DeltaCoin,
+            required: Coin,
+        },
+        /// Tag: 14
+        ScriptsNotPaidUTxO {
+            offending_utxo: UTxO<Era>,
+        },
+        /// Tag: 15
+        ExUnitsTooBigUTxO {
+            bound: Mismatch<RelLTEQ, ExUnits>,
+        },
+        /// Tag: 16
+        CollateralContainsNonADA {
+            value: Value<Era>,
+        },
+        /// Tag: 17
+        WrongNetworkInTxBody {
+            mismatch: Mismatch<RelEQ, NetworkId>,
+        },
+        /// Tag: 18
+        OutsideForecast {
+            slot: SlotNo,
+        },
+        /// Tag: 19
+        TooManyCollateralInputs {
+            bound: Mismatch<RelLTEQ, usize>,
+        },
+        /// Tag: 20
+        NoCollateralInputs,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum FailureDescription {
+        /// Tag: 0
+        PassedUnexpectedly,
+        /// Tag: 1
+        FailedUnexpectedly(Vec<FailureDescription>),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum UtxosPredicateFailure<Era> {
+        /// Tag: 0
+        ValidationTagMismatch {
+            is_valid: bool,
+            description: FailureDescription,
+        },
+        /// Tag: 1
+        CollectErrors {
+            errors: Vec<CollectError<Era>>,
+        },
+        /// Tag: 2
+        UpdateFailure(super::shelley::PpupPredicateFailure),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum CollectError<Era> {
+        // Placeholder; see `collectTwoPhaseScriptInputs` for full shape.
+        /// TODO: encode exact variants from `CollectError`.
+        Placeholder, // TODO: encode exact variants from `CollectError`.
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum UtxowPredicateFailure<Era> {
+        /// Tag: 0
+        ShelleyInAlonzo(super::shelley::UtxowPredicateFailure<Era>),
+        /// Tag: 1
+        MissingRedeemers {
+            missing: Vec<(PlutusPurpose<AsItem, Era>, ScriptHash)>,
+        },
+        /// Tag: 2
+        MissingRequiredDatums {
+            missing_hashes: BTreeSet<DataHash>,
+            provided_hashes: BTreeSet<DataHash>,
+        },
+        /// Tag: 3
+        NotAllowedSupplementalDatums {
+            forbidden_hashes: BTreeSet<DataHash>,
+            permitted: BTreeSet<DataHash>,
+        },
+        /// Tag: 4
+        PPViewHashesDontMatch {
+            mismatch: Mismatch<RelEQ, StrictMaybe<ScriptIntegrityHash>>,
+        },
+        /// Tag: 6
+        UnspendableUTxONoDatumHash {
+            inputs: BTreeSet<TxIn>,
+        },
+        /// Tag: 7
+        ExtraRedeemers {
+            extra: Vec<PlutusPurpose<AsIx, Era>>,
+        },
+        /// Tag: 8
+        ScriptIntegrityHashMismatch {
+            mismatch: Mismatch<RelEQ, StrictMaybe<ScriptIntegrityHash>>,
+            provided: StrictMaybe<Vec<u8>>,
+        },
+    }
+
+}
+
+// ---------------------------------------------------------------------------
+// Babbage era predicate failures
+// ---------------------------------------------------------------------------
+
+pub mod babbage {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum UtxoPredicateFailure<Era> {
+        /// Tag: 1
+        AlonzoInBabbage(super::alonzo::UtxoPredicateFailure<Era>),
+        /// Tag: 2
+        IncorrectTotalCollateralField {
+            provided: DeltaCoin,
+            declared: Coin,
+        },
+        /// Tag: 3
+        OutputTooSmall {
+            outputs: Vec<(TxOut<Era>, Coin)>,
+        },
+        /// Tag: 4
+        NonDisjointReferenceInputs {
+            overlapping: Vec<TxIn>,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum UtxowPredicateFailure<Era> {
+        /// Tag: 1
+        AlonzoInBabbage(super::alonzo::UtxowPredicateFailure<Era>),
+        /// Tag: 2
+        UtxoFailure(UtxoPredicateFailure<Era>),
+        /// Tag: 3
+        MalformedScriptWitnesses {
+            witnesses: BTreeSet<ScriptHash>,
+        },
+        /// Tag: 4
+        MalformedReferenceScripts {
+            scripts: BTreeSet<ScriptHash>,
+        },
+        /// Tag: 5
+        ScriptIntegrityHashMismatch {
+            mismatch: Mismatch<RelEQ, StrictMaybe<ScriptIntegrityHash>>,
+            provided: StrictMaybe<Vec<u8>>,
+        },
+    }
+
+    // TODO: Extend with Babbage-specific ledgers/bbody predicate failures when
+    // serialisation hooks are required.
+}
+
+// ---------------------------------------------------------------------------
+// Conway era predicate failures
+// ---------------------------------------------------------------------------
+
+pub mod conway {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum UtxosPredicateFailure<Era> {
+        /// Tag: 0
+        ValidationTagMismatch {
+            tag: IsValid,
+            description: TagMismatchDescription,
+        },
+        /// Tag: 1
+        CollectErrors {
+            errors: Vec<super::alonzo::CollectError<Era>>,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum UtxoPredicateFailure<Era> {
+        /// Tag: 0
+        UtxosFailure(UtxosPredicateFailure<Era>),
+        /// Tag: 1
+        BadInputsUTxO {
+            invalid_inputs: BTreeSet<TxIn>,
+        },
+        /// Tag: 2
+        OutsideValidityIntervalUTxO {
+            validity_interval: ValidityInterval,
+            current_slot: SlotNo,
+        },
+        /// Tag: 3
+        MaxTxSizeUTxO {
+            size_mismatch: Mismatch<RelLTEQ, Word32>,
+        },
+        /// Tag: 4
+        InputSetEmptyUTxO,
+        /// Tag: 5
+        FeeTooSmallUTxO {
+            fee_mismatch: Mismatch<RelGTEQ, Coin>,
+        },
+        /// Tag: 6
+        ValueNotConservedUTxO {
+            balance_mismatch: Mismatch<RelEQ, Value<Era>>,
+        },
+        /// Tag: 7
+        WrongNetwork {
+            expected: NetworkId,
+            offending: BTreeSet<Address>,
+        },
+        /// Tag: 8
+        WrongNetworkWithdrawal {
+            expected: NetworkId,
+            offending: BTreeSet<RewardAccount>,
+        },
+        /// Tag: 9
+        OutputTooSmallUTxO {
+            tiny_outputs: Vec<TxOut<Era>>,
+        },
+        /// Tag: 10
+        OutputBootAddrAttrsTooBig {
+            oversized_bootstrap_outputs: Vec<TxOut<Era>>,
+        },
+        /// Tag: 11
+        OutputTooBigUTxO {
+            // (actual_size, max_size, output)
+            outputs: Vec<(i64, i64, TxOut<Era>)>,
+        },
+        /// Tag: 12
+        InsufficientCollateral {
+            provided: DeltaCoin,
+            required: Coin,
+        },
+        /// Tag: 13
+        ScriptsNotPaidUTxO {
+            unpaid: UTxO<Era>,
+        },
+        /// Tag: 14
+        ExUnitsTooBigUTxO {
+            limit_mismatch: Mismatch<RelLTEQ, ExUnits>,
+        },
+        /// Tag: 15
+        CollateralContainsNonADA {
+            offending_value: Value<Era>,
+        },
+        /// Tag: 16
+        WrongNetworkInTxBody {
+            mismatch: Mismatch<RelEQ, NetworkId>,
+        },
+        /// Tag: 17
+        OutsideForecast {
+            slot: SlotNo,
+        },
+        /// Tag: 18
+        TooManyCollateralInputs {
+            bound: Mismatch<RelLTEQ, Natural>,
+        },
+        /// Tag: 19
+        NoCollateralInputs,
+        /// Tag: 20
+        IncorrectTotalCollateralField {
+            provided: DeltaCoin,
+            declared: Coin,
+        },
+        /// Tag: 21
+        BabbageOutputTooSmallUTxO {
+            outputs: Vec<(TxOut<Era>, Coin)>,
+        },
+        /// Tag: 22
+        BabbageNonDisjointRefInputs {
+            overlapping: NonEmpty<TxIn>,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum UtxowPredicateFailure<Era> {
+        /// Tag: 0
+        UtxoFailure(UtxoPredicateFailure<Era>),
+        /// Tag: 1
+        InvalidWitnessesUTXOW {
+            witnesses: Vec<VerificationKey>,
+        },
+        /// Tag: 2
+        MissingVKeyWitnessesUTXOW {
+            missing: BTreeSet<KeyHash>,
+        },
+        /// Tag: 3
+        MissingScriptWitnessesUTXOW {
+            missing: BTreeSet<ScriptHash>,
+        },
+        /// Tag: 4
+        ScriptWitnessNotValidatingUTXOW {
+            failing: BTreeSet<ScriptHash>,
+        },
+        /// Tag: 5
+        MissingTxBodyMetadataHash {
+            expected: TxAuxDataHash,
+        },
+        /// Tag: 6
+        MissingTxMetadata {
+            expected: TxAuxDataHash,
+        },
+        /// Tag: 7
+        ConflictingMetadataHash {
+            mismatch: Mismatch<RelEQ, TxAuxDataHash>,
+        },
+        /// Tag: 8
+        InvalidMetadata,
+        /// Tag: 9
+        ExtraneousScriptWitnessesUTXOW {
+            extraneous: BTreeSet<ScriptHash>,
+        },
+        /// Tag: 10
+        MissingRedeemers {
+            missing: Vec<(PlutusPurpose<AsItem, Era>, ScriptHash)>,
+        },
+        /// Tag: 11
+        MissingRequiredDatums {
+            missing_hashes: BTreeSet<DataHash>,
+            provided_hashes: BTreeSet<DataHash>,
+        },
+        /// Tag: 12
+        NotAllowedSupplementalDatums {
+            disallowed_hashes: BTreeSet<DataHash>,
+            allowed: BTreeSet<DataHash>,
+        },
+        /// Tag: 13
+        PPViewHashesDontMatch {
+            mismatch: Mismatch<RelEQ, StrictMaybe<ScriptIntegrityHash>>,
+        },
+        /// Tag: 14
+        UnspendableUTxONoDatumHash {
+            inputs: BTreeSet<TxIn>,
+        },
+        /// Tag: 15
+        ExtraRedeemers {
+            extra: Vec<PlutusPurpose<AsIx, Era>>,
+        },
+        /// Tag: 16
+        MalformedScriptWitnesses {
+            scripts: BTreeSet<ScriptHash>,
+        },
+        /// Tag: 17
+        MalformedReferenceScripts {
+            scripts: BTreeSet<ScriptHash>,
+        },
+        /// Tag: 18
+        ScriptIntegrityHashMismatch {
+            mismatch: Mismatch<RelEQ, StrictMaybe<ScriptIntegrityHash>>,
+            provided: StrictMaybe<ByteString>,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum DelegPredicateFailure {
+        /// Tag: 1
+        IncorrectDepositDELEG {
+            deposit: Coin,
+        },
+        /// Tag: 2
+        StakeKeyRegisteredDELEG {
+            stake_credential: StakeCredential,
+        },
+        /// Tag: 3
+        StakeKeyNotRegisteredDELEG {
+            stake_credential: StakeCredential,
+        },
+        /// Tag: 4
+        StakeKeyHasNonZeroRewardAccountBalanceDELEG {
+            balance: Coin,
+        },
+        /// Tag: 5
+        DelegateeDRepNotRegisteredDELEG {
+            delegatee: DRepCredential,
+        },
+        /// Tag: 6
+        DelegateeStakePoolNotRegisteredDELEG {
+            delegatee: PoolKeyHash,
+        },
+        /// Tag: 7
+        DepositIncorrectDELEG {
+            mismatch: Mismatch<RelEQ, Coin>,
+        },
+        /// Tag: 8
+        RefundIncorrectDELEG {
+            mismatch: Mismatch<RelEQ, Coin>,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum GovCertPredicateFailure {
+        /// Tag: 0
+        ConwayDRepAlreadyRegistered {
+            credential: DRepCredential,
+        },
+        /// Tag: 1
+        ConwayDRepNotRegistered {
+            credential: DRepCredential,
+        },
+        /// Tag: 2
+        ConwayDRepIncorrectDeposit {
+            mismatch: Mismatch<RelEQ, Coin>,
+        },
+        /// Tag: 3
+        ConwayCommitteeHasPreviouslyResigned {
+            cold_credential: CommitteeColdCredential,
+        },
+        /// Tag: 4
+        ConwayDRepIncorrectRefund {
+            mismatch: Mismatch<RelEQ, Coin>,
+        },
+        /// Tag: 5
+        ConwayCommitteeIsUnknown {
+            cold_credential: CommitteeColdCredential,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum CertPredicateFailure<Era> {
+        /// Tag: 1
+        DelegFailure(DelegPredicateFailure),
+        /// Tag: 2
+        PoolFailure(super::shelley::PoolPredicateFailure),
+        /// Tag: 3
+        GovCertFailure(GovCertPredicateFailure),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum CertsPredicateFailure<Era> {
+        /// Tag: 0
+        WithdrawalsNotInRewardsCERTS {
+            withdrawals: Withdrawals,
+        },
+        /// Tag: 1
+        CertFailure(CertPredicateFailure<Era>),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum GovPredicateFailure<Era> {
+        /// Tag: 0
+        GovActionsDoNotExist {
+            missing: NonEmpty<GovActionId>,
+        },
+        /// Tag: 1
+        MalformedProposal {
+            proposal: GovAction<Era>,
+        },
+        /// Tag: 2
+        ProposalProcedureNetworkIdMismatch {
+            reward_account: RewardAccount,
+            expected_network: NetworkId,
+        },
+        /// Tag: 3
+        TreasuryWithdrawalsNetworkIdMismatch {
+            offending_accounts: BTreeSet<RewardAccount>,
+            expected_network: NetworkId,
+        },
+        /// Tag: 4
+        ProposalDepositIncorrect {
+            mismatch: Mismatch<RelEQ, Coin>,
+        },
+        /// Tag: 5
+        DisallowedVoters {
+            voters: NonEmpty<(Voter, GovActionId)>,
+        },
+        /// Tag: 6
+        ConflictingCommitteeUpdate {
+            members: BTreeSet<CommitteeColdCredential>,
+        },
+        /// Tag: 7
+        ExpirationEpochTooSmall {
+            expired: BTreeMap<CommitteeColdCredential, EpochNo>,
+        },
+        /// Tag: 8
+        InvalidPrevGovActionId {
+            proposal: ProposalProcedure<Era>,
+        },
+        /// Tag: 9
+        VotingOnExpiredGovAction {
+            votes: NonEmpty<(Voter, GovActionId)>,
+        },
+        /// Tag: 10
+        ProposalCantFollow {
+            previous: StrictMaybe<GovPurposeId<HardForkPurpose>>,
+            version_mismatch: Mismatch<RelGT, ProtVer>,
+        },
+        /// Tag: 11
+        InvalidPolicyHash {
+            provided: StrictMaybe<ScriptHash>,
+            expected: StrictMaybe<ScriptHash>,
+        },
+        /// Tag: 12
+        DisallowedProposalDuringBootstrap {
+            proposal: ProposalProcedure<Era>,
+        },
+        /// Tag: 13
+        DisallowedVotesDuringBootstrap {
+            votes: NonEmpty<(Voter, GovActionId)>,
+        },
+        /// Tag: 14
+        VotersDoNotExist {
+            voters: NonEmpty<Voter>,
+        },
+        /// Tag: 15
+        ZeroTreasuryWithdrawals {
+            action: GovAction<Era>,
+        },
+        /// Tag: 16
+        ProposalReturnAccountDoesNotExist {
+            reward_account: RewardAccount,
+        },
+        /// Tag: 17
+        TreasuryWithdrawalReturnAccountsDoNotExist {
+            reward_accounts: NonEmpty<RewardAccount>,
+        },
+        /// Tag: 18
+        UnelectedCommitteeVoters {
+            voters: NonEmpty<CommitteeHotCredential>,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum LedgerPredicateFailure<Era> {
+        /// Tag: 1
+        ConwayUtxowFailure(UtxowPredicateFailure<Era>),
+        /// Tag: 2
+        ConwayCertsFailure(CertsPredicateFailure<Era>),
+        /// Tag: 3
+        ConwayGovFailure(GovPredicateFailure<Era>),
+        /// Tag: 4
+        ConwayWdrlNotDelegatedToDRep {
+            withdrawals: NonEmpty<AddrKeyHash>,
+        },
+        /// Tag: 5
+        ConwayTreasuryValueMismatch {
+            // Serialisation swaps supplied/expected relative to this struct.
+            mismatch: Mismatch<RelEQ, Coin>,
+        },
+        /// Tag: 6
+        ConwayTxRefScriptsSizeTooBig {
+            size_mismatch: Mismatch<RelLTEQ, i64>,
+        },
+        /// Tag: 7
+        ConwayMempoolFailure {
+            reason: Text,
+        },
+        /// Tag: 8
+        ConwayWithdrawalsMissingAccounts {
+            withdrawals: Withdrawals,
+        },
+        /// Tag: 9
+        ConwayIncompleteWithdrawals {
+            withdrawals: Withdrawals,
+        },
+    }
+}

--- a/docs/rust_rule_errors.rs
+++ b/docs/rust_rule_errors.rs
@@ -1,11 +1,12 @@
-//! Rust representations of STS predicate failure types extracted from the
-//! Cardano ledger `Rules` modules across eras.
+//! Rust representations of the transaction-submission STS predicate failures
+//! extracted from the Cardano ledger `Rules` modules across eras.
 //!
 //! NOTE: These definitions focus on the structure and CBOR tags of the
-//! predicate failure enums. Domain-specific payload types are represented by
-//! lightweight stand-ins so the relationships between failures remain clear.
-//! Replace them with the concrete ledger types when wiring these definitions
-//! into production code.
+//! predicate failure enums that can arise when the mempool validates a
+//! transaction. Domain-specific payload types are represented by lightweight
+//! stand-ins so the relationships between failures remain clear. Replace them
+//! with the concrete ledger types when wiring these definitions into
+//! production code.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -926,23 +927,6 @@ pub mod shelley {
         DelegsFailure(DelegsPredicateFailure<Era>),
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub enum BbodyPredicateFailure<Era> {
-        // No explicit CBOR instance in the source; tags unknown.
-        WrongBlockBodySizeBBODY {
-            mismatch: Mismatch<RelEQ, usize>,
-        },
-        InvalidBodyHashBBODY {
-            mismatch: Mismatch<RelEQ, BlockBodyHash>,
-        },
-        LedgersFailure(LedgersPredicateFailure<Era>),
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub enum LedgersPredicateFailure<Era> {
-        /// Tag 0 relayed through `ShelleyBbodyPredFailure`
-        LedgersFailure(LedgerPredicateFailure<Era>),
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1018,16 +1002,6 @@ pub mod mary {
 
 pub mod alonzo {
     use super::*;
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub enum BbodyPredicateFailure<Era> {
-        /// Tag: 0
-        ShelleyInAlonzo(super::shelley::BbodyPredicateFailure<Era>),
-        /// Tag: 1
-        TooManyExUnits {
-            bound: Mismatch<RelLTEQ, ExUnits>,
-        },
-    }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub enum UtxoPredicateFailure<Era> {


### PR DESCRIPTION
## Summary
- expand the Conway predicate failure enums to cover every tagged constructor and keep the payload terms
- add tag enums and helpers so the decoder walks the full ledger/governance hierarchy instead of stopping at certificates
- share expect_* utilities to validate constructor arity and remove the lingering TODO about Conway coverage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2c9fff4a88328a5ef657dab8fa313